### PR TITLE
Split deploy workflow by target

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -174,10 +174,10 @@ jobs:
               generateArchitectureArtifacts \
               generateArticleSummaries
 
-  deploy:
+  deploy-site:
     needs: [build-docs, detect-changes]
     runs-on: ubuntu-latest
-    if: needs.build-docs.outputs.isBuilt == 'true'
+    if: needs.build-docs.outputs.isBuilt == 'true' && needs.detect-changes.outputs.site == 'true'
     environment:
       name: production
     env:
@@ -194,12 +194,9 @@ jobs:
           path: build
 
       - name: Install lftp
-        if: needs.detect-changes.outputs.site == 'true' || needs.detect-changes.outputs.architecture == 'true'
         run: sudo apt-get update && sudo apt-get install -y lftp
 
-      # --- Upload Site ---
       - name: Deploy site to private webspace
-        if: needs.detect-changes.outputs.site == 'true'
         run: |
           lftp -u "$SFTP_USER","$SFTP_PASSWORD" sftp://$SFTP_HOST:$SFTP_PORT <<EOF
           set sftp:auto-confirm yes
@@ -209,9 +206,29 @@ jobs:
           bye
           EOF
 
-      # --- Upload Architecture ---
+  deploy-architecture:
+    needs: [build-docs, detect-changes]
+    runs-on: ubuntu-latest
+    if: needs.build-docs.outputs.isBuilt == 'true' && needs.detect-changes.outputs.architecture == 'true'
+    environment:
+      name: production
+    env:
+      SFTP_HOST: ${{ vars.SFTP_HOST }}
+      SFTP_PORT: ${{ vars.SFTP_PORT }}
+      SFTP_USER: ${{ vars.SFTP_USER }}
+      SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+      SFTP_REMOTE_BASE: ${{ vars.SFTP_REMOTE_BASE }}
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: build
+
+      - name: Install lftp
+        run: sudo apt-get update && sudo apt-get install -y lftp
+
       - name: Deploy architecture to private webspace
-        if: needs.detect-changes.outputs.architecture == 'true'
         run: |
           lftp -u "$SFTP_USER","$SFTP_PASSWORD" sftp://$SFTP_HOST:$SFTP_PORT <<EOF
           set sftp:auto-confirm yes
@@ -221,9 +238,18 @@ jobs:
           bye
           EOF
 
-      # --- GitHub README ---
+  deploy-github-readme:
+    needs: [build-docs, detect-changes]
+    runs-on: ubuntu-latest
+    if: needs.build-docs.outputs.isBuilt == 'true' && needs.detect-changes.outputs.readme == 'true'
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: build
+
       - name: checkout github profile repo
-        if: needs.detect-changes.outputs.readme == 'true'
         uses: actions/checkout@v4
         with:
           repository: dieterbaier/dieterbaier
@@ -231,7 +257,6 @@ jobs:
           path: profile
 
       - name: update readme on profile repo
-        if: needs.detect-changes.outputs.readme == 'true'
         run: |
           cp build/readme/README.md profile/README.md
           cd profile
@@ -241,9 +266,18 @@ jobs:
           git commit -m "update README" || echo "no changes"
           git push origin HEAD:main
 
-      # --- GitLab README ---
+  deploy-gitlab-readme:
+    needs: [build-docs, detect-changes]
+    runs-on: ubuntu-latest
+    if: needs.build-docs.outputs.isBuilt == 'true' && needs.detect-changes.outputs.readme == 'true'
+
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: docs
+          path: build
+
       - name: push readme to gitlab profile
-        if: needs.detect-changes.outputs.readme == 'true'
         run: |
           git clone https://oauth2:${{ secrets.GITLAB_TOKEN }}@gitlab.com/brdietdidi/brdietdidi.git gitlab-repo
           cp build/readme/README.md gitlab-repo/README.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,7 @@
 - Preserve user changes. Do not revert unrelated work.
 - Prefer existing project patterns in Gradle, AsciiDoc, architecture documentation, generic skill layout, and adapter layout.
 - When changing build behavior, run the narrowest relevant Gradle task and report any warnings that remain.
+- When working from a GitHub issue, use the `architecture-knowledge-toolkit` issue workflow and commit message skills where applicable. In particular, format issue commit messages according to `skills/commit-message/SKILL.md` from the toolkit, for example `issue_23: Split deploy workflow by target`.
 
 ## Contract And Adapter Discovery
 

--- a/README.md
+++ b/README.md
@@ -183,18 +183,39 @@ To enable the pipeline to use personal information (which is included in the doc
     secrets.GITLAB_TOKEN              # To be able to deploy the README.md files
     secrets.PROFILE_REPO_TOKEN
 
-    secrets.SFTP_PASSWORD             # To deploy the website and architcture documentation to the personal webspace
+    secrets.SFTP_PASSWORD             # To deploy the website and architecture documentation to the personal webspace
     vars.SFTP_REMOTE_BASE
     vars.SFTP_HOST
     vars.SFTP_PORT
     vars.SFTP_USER
 
-The pipeline builds and deployes
+Credential ownership:
+
+| Name | GitHub Actions scope | Purpose | Required access |
+| --- | --- | --- | --- |
+| `PROFILE_REPO_TOKEN` | repository secret in `dieterbaier/profile` | Checkout and push the generated README to `dieterbaier/dieterbaier` | Fine-grained GitHub token for `dieterbaier/dieterbaier` with `Contents: Read and write` |
+| `GITLAB_TOKEN` | repository secret in `dieterbaier/profile` | Clone and push the generated README to `gitlab.com/brdietdidi/brdietdidi` | GitLab token with repository write access |
+| `SFTP_PASSWORD` | `production` environment secret in `dieterbaier/profile` | Upload site and architecture artifacts to the private webspace | SFTP password for the configured deployment user |
+| `SITE_*` secrets | `production` environment secrets in `dieterbaier/profile` | Inject private contact data during site/CV generation | Values only, no repository access |
+| `SFTP_*` variables | `production` environment variables in `dieterbaier/profile` | Configure SFTP target host, port, user, and remote base path | Non-secret deployment configuration |
+
+Token rotation:
+
+1. Create a new fine-grained GitHub personal access token for the target repository `dieterbaier/dieterbaier`.
+2. Grant `Contents: Read and write`. Do not grant broader account permissions unless the workflow needs them later.
+3. Update the repository secret `PROFILE_REPO_TOKEN` in `dieterbaier/profile`.
+4. Re-run the failed `Build Docs` workflow or trigger it with `workflow_dispatch`.
+
+If the README deploy fails in the `checkout github profile repo` step with `Bad credentials`, rotate `PROFILE_REPO_TOKEN`. If the GitLab README step fails during clone or push, rotate `GITLAB_TOKEN`. If the private webspace upload fails during `lftp`, check `SFTP_PASSWORD` and the `SFTP_*` variables.
+
+The pipeline builds and deploys
 
 - README.md to https://github.com/dieterbaier (has to be improved so it is not fixed)
 - README.md to https://gitlab.com/brdietdidi (has to be improved so it is not fixed)
 - The profile website (including the cv.pdf, which can be downloaded from the website) to `<vars.SFTP_REMOTE_BASE>/site`
 - The architecture documentation to `<vars.SFTP_REMOTE_BASE>/architecture`
+
+Each deployment target has its own GitHub Actions job. This allows a failed target deployment to be re-run without deploying already successful targets again.
 
 When article sources change, the pipeline also builds Markdown exports under `build/articles` as part of the uploaded build artifact.
 

--- a/general-semantic-contracts.md
+++ b/general-semantic-contracts.md
@@ -45,6 +45,15 @@ Use:
 ./gradlew generateArchitectureArtifacts
 ```
 
+When this repository references `architecture-knowledge-toolkit`, treat that
+toolkit as the canonical source for architecture contracts, task skills,
+templates, metamodel schemas, validators, and generators. Project-local
+instructions and contracts still win when they deliberately narrow or override
+the toolkit. For issue implementation, pull request review, ADRs, quality
+scenarios, risks, traceability, and commit messages, use the corresponding
+toolkit `skills/**/SKILL.md` and contract guidance where applicable instead of
+recreating those rules locally.
+
 ## Profile Knowledge
 
 Profile content under `src-content/profile` is treated as product source.

--- a/src-content/docs/arc42/04_solution_strategy/Build_Pipeline_Strategy.adoc
+++ b/src-content/docs/arc42/04_solution_strategy/Build_Pipeline_Strategy.adoc
@@ -62,14 +62,31 @@ Artifacts are::
 
 - generated once
 - uploaded
-- consumed by a dedicated deploy stage
+- consumed by target-specific deploy jobs
 
 Deployment targets::
 
 - GitHub profile README
 - GitLab profile README
-- GitHub Pages
-- personal domain
+- personal website on private webspace
+- architecture documentation on private webspace
+
+==== 5. Scoped Deployment Credentials
+
+Deployment credentials are separated by target:
+
+[cols="1,2,2", options="header"]
+|===
+| Target | Credential | Access model
+| GitHub profile README | `PROFILE_REPO_TOKEN` repository secret | Fine-grained GitHub personal access token for `dieterbaier/dieterbaier` with `Contents: Read and write`
+| GitLab profile README | `GITLAB_TOKEN` repository secret | GitLab token with repository write access
+| Personal website and architecture documentation | `SFTP_PASSWORD` production environment secret, `SFTP_*` variables | SFTP deployment to the configured private webspace
+| Personal contact data | `SITE_*` production environment secrets | Value injection during generation, no repository access
+|===
+
+Each deployment target is implemented as a separate GitHub Actions job. This keeps re-runs focused on the failed target and avoids repeating successful deployments when one target fails.
+
+Token failures are diagnosed at the target-specific step. `Bad credentials` in `checkout github profile repo` points to `PROFILE_REPO_TOKEN`. GitLab clone or push failures point to `GITLAB_TOKEN`. SFTP login or transfer failures point to `SFTP_PASSWORD` or the `SFTP_*` variables.
 
 === Consequences
 
@@ -79,8 +96,10 @@ Advantages::
 - Lower resource consumption
 - Deterministic builds
 - Clear separation of concerns
+- Smaller credential blast radius per deployment target
 
 Trade-offs::
 
 - Increased pipeline complexity
 - Additional maintenance for path filters
+- Token expiry and rotation must be operated explicitly

--- a/src-content/docs/arc42/doc-04000-solution-strategy.adoc
+++ b/src-content/docs/arc42/doc-04000-solution-strategy.adoc
@@ -7,7 +7,7 @@ owner: "Dieter Baier"
 created: '2026-07-04'
 reviewed: false
 generated: false
-summary: "Key architectural approaches for content, validation, generation, and deployment."
+summary: "Key architectural approaches for content, validation, generation, deployment, and credential handling."
 tags:
 - arc42
 - architecture
@@ -24,5 +24,34 @@ metadata_version: '1.0'
 | Metadata-backed content | QG-002, QG-004 | Standalone content artifacts receive front matter; include-heavy reusable fragments are covered by sidecar metadata.
 | Toolkit-compatible architecture knowledge | QG-002, QG-003 | arc42 chapters, ADRs, quality scenarios, risks, schemas, validators, and generated fragments follow architecture-knowledge-toolkit conventions.
 | Gradle task orchestration | QG-001, QG-003 | Build, validation, and generation are exposed as repeatable Gradle tasks.
-| Containerized CI/CD | QG-001, QG-005 | GitHub Actions run the same toolchain in the docs-toolbox container and deploy only changed outputs.
+| Containerized CI/CD | QG-001, QG-005 | GitHub Actions run the same toolchain in the docs-toolbox container and deploy changed outputs through target-specific deploy jobs.
+| Scoped deployment credentials | QG-005 | Deployment credentials are separated by target. GitHub profile README deployment uses a fine-grained token for `dieterbaier/dieterbaier`; GitLab README deployment uses a GitLab token; private webspace deployment uses SFTP credentials.
 |===
+
+== Build Pipeline Strategy
+
+The GitHub Actions workflow separates change detection, build execution, artifact upload, and target-specific deployment.
+
+Only changed target categories trigger the matching Gradle tasks:
+
+[cols="1,2", options="header"]
+|===
+| Change category | Build output
+| README | `build/readme/README.md`
+| Articles | Markdown exports under `build/articles`
+| Architecture | `build/architecture`
+| Site | `build/site`
+|===
+
+Generated artifacts are uploaded once and consumed by separate deploy jobs. Each deploy job owns one deployment target so failed deployments can be re-run without repeating successful targets. The deploy jobs use target-specific credentials instead of one shared deployment token:
+
+[cols="1,2,2", options="header"]
+|===
+| Target | Credential | Reason
+| GitHub profile README | `PROFILE_REPO_TOKEN` repository secret | Cross-repository push to `dieterbaier/dieterbaier` requires write access to the target repository.
+| GitLab profile README | `GITLAB_TOKEN` repository secret | GitLab push requires a GitLab credential independent of GitHub Actions.
+| Personal website and architecture documentation | `SFTP_PASSWORD` production environment secret plus `SFTP_*` variables | Private webspace deployment is external to GitHub and uses SFTP.
+| Personal contact data | `SITE_*` production environment secrets | Private data is injected only during CI generation and is not stored in source files.
+|===
+
+`PROFILE_REPO_TOKEN` should be a fine-grained GitHub personal access token scoped to `dieterbaier/dieterbaier` with `Contents: Read and write`. A failure in the `checkout github profile repo` step with `Bad credentials` indicates that this token is invalid, expired, revoked, or missing the required target repository permission.

--- a/src-content/docs/arc42/doc-07000-deployment-view.adoc
+++ b/src-content/docs/arc42/doc-07000-deployment-view.adoc
@@ -7,7 +7,7 @@ owner: "Dieter Baier"
 created: '2026-07-04'
 reviewed: false
 generated: false
-summary: "Deployment environments and generated targets."
+summary: "Deployment environments, generated targets, and deployment credentials."
 tags:
 - arc42
 - architecture
@@ -26,3 +26,19 @@ metadata_version: '1.0'
 | GitLab profile README | Git push from GitHub Actions | `build/readme/README.md`
 | Personal CV PDF | Local build artifact, not deployed by default | `build/cv/cv.pdf`
 |===
+
+The deploy workflow uses one GitHub Actions job per deployed target. A failed target job can be re-run independently without deploying targets that already succeeded.
+
+== Deployment Credentials
+
+[cols="1,2,2,2", options="header"]
+|===
+| Target | GitHub Actions configuration | Stored in | Required permission
+| GitHub profile README | `PROFILE_REPO_TOKEN` | Repository secret in `dieterbaier/profile` | Fine-grained GitHub token for `dieterbaier/dieterbaier` with `Contents: Read and write`
+| GitLab profile README | `GITLAB_TOKEN` | Repository secret in `dieterbaier/profile` | GitLab repository write access
+| Personal website | `SFTP_PASSWORD`, `SFTP_HOST`, `SFTP_PORT`, `SFTP_USER`, `SFTP_REMOTE_BASE` | `SFTP_PASSWORD` as `production` environment secret; `SFTP_*` values as `production` environment variables | SFTP write access to the configured site directory
+| Architecture documentation | `SFTP_PASSWORD`, `SFTP_HOST`, `SFTP_PORT`, `SFTP_USER`, `SFTP_REMOTE_BASE` | `SFTP_PASSWORD` as `production` environment secret; `SFTP_*` values as `production` environment variables | SFTP write access to the configured architecture directory
+| Private contact data | `SITE_EMAIL`, `SITE_ADDRESS_NAME`, `SITE_STREET`, `SITE_PLZ`, `SITE_CITY`, `SITE_TEL` | `production` environment secrets in `dieterbaier/profile` | Value injection only; no repository or deployment permission
+|===
+
+The GitHub profile README is deployed to a different repository than the workflow source repository. The default `GITHUB_TOKEN` is intentionally not used for this cross-repository push; it is scoped to the workflow repository. `PROFILE_REPO_TOKEN` therefore has to be rotated when it expires or when GitHub reports `Bad credentials` during the `checkout github profile repo` step.

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -21,6 +21,8 @@ metadata_version: '1.0'
 
 Private contact data and deployment credentials are injected from environment variables or GitHub Secrets. `.env` is local-only.
 
+Deployment credentials are scoped by target system. `PROFILE_REPO_TOKEN` grants write access only to the GitHub profile README target repository. `GITLAB_TOKEN` grants write access to the GitLab profile README target repository. SFTP credentials are used only for private webspace deployment. This avoids one shared credential for all deployment targets and makes token rotation diagnosable from the failing workflow step.
+
 == Testing And Validation
 
 Metadata validation runs before documentation rendering. The architecture validator follows the architecture-knowledge-toolkit metamodel. The profile validator checks profile artifact metadata, relations, and generated indexes.


### PR DESCRIPTION
## Summary
- split the single deploy job into target-specific jobs for site, architecture, GitHub README, and GitLab README
- keep build artifacts generated once and downloaded by each deploy job
- document deployment credential ownership, token rotation, and target-specific re-runs

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/update-profile.yml"); puts "YAML OK"'
- ./gradlew validateArchitectureMetamodel
- git diff --check

Closes #23