### PR TITLE
Update toolkit skill references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@
 - Preserve user changes. Do not revert unrelated work.
 - Prefer existing project patterns in Gradle, AsciiDoc, architecture documentation, generic skill layout, and adapter layout.
 - When changing build behavior, run the narrowest relevant Gradle task and report any warnings that remain.
-- When working from a GitHub issue, use the `architecture-knowledge-toolkit` issue workflow and commit message skills where applicable. In particular, format issue commit messages according to `skills/commit-message/SKILL.md` from the toolkit, for example `issue_23: Split deploy workflow by target`.
+- When working from a GitHub issue, use the `architecture-knowledge-toolkit` SDLC skills where applicable, including issue slicing, issue implementation, architecture impact analysis, commit messages, pull request reviews, and post-merge synchronization. In particular, format issue commit messages according to `skills/commit-message/SKILL.md` from the toolkit, for example `issue_23: Split deploy workflow by target`.
 
 ## Contract And Adapter Discovery
 
@@ -20,6 +20,7 @@
 
 - This repository belongs to the docs-as-code-toolkit context.
 - If architecture documentation, ADRs, quality scenarios, risks, traceability, metadata, templates, validators, or generators are requested, use the architecture-knowledge-toolkit where applicable.
+- For toolkit-backed architecture work, use the matching toolkit skills where applicable, including `adr`, `quality-scenario`, `risk`, `traceability-review`, `architecture-impact`, and `domain-modeling`.
 - Project-local instructions and contracts win over generic toolkit conventions.
 - Architecture source follows the architecture-knowledge-toolkit structure under `src-content/docs`.
 - Run `./gradlew validateArchitectureMetamodel` or `./gradlew generateArchitectureArtifacts` after changing architecture metadata or traceability.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -37,7 +37,8 @@ Project-local skills:
 
 Toolkit-provided skills are not copied into this project. For architecture and
 SDLC work covered by `architecture-knowledge-toolkit`, inspect the matching
-toolkit `skills/**/SKILL.md`, including issue slicing, issue implementation,
-architecture impact analysis, commit messages, pull request review, post-merge
-synchronization, ADRs, quality scenarios, risks, traceability review, and domain
-modeling.
+toolkit `skills/**/SKILL.md`, including issue slicing
+(`skills/slice-issues/SKILL.md`), issue implementation
+(`skills/implement-issue-workflow/SKILL.md`), architecture impact analysis,
+commit messages, pull request review, post-merge synchronization, ADRs, quality
+scenarios, risks, traceability review, and domain modeling.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -29,6 +29,15 @@ skills/<skill-name>/SKILL.md
 
 ## Current Skills
 
+Project-local skills:
+
 - `skills/article-summary-pack/SKILL.md`
 - `skills/write-article/SKILL.md`
 - `skills/profile-artifact-maintenance/SKILL.md`
+
+Toolkit-provided skills are not copied into this project. For architecture and
+SDLC work covered by `architecture-knowledge-toolkit`, inspect the matching
+toolkit `skills/**/SKILL.md`, including issue slicing, issue implementation,
+architecture impact analysis, commit messages, pull request review, post-merge
+synchronization, ADRs, quality scenarios, risks, traceability review, and domain
+modeling.

--- a/general-semantic-contracts.md
+++ b/general-semantic-contracts.md
@@ -47,11 +47,13 @@ Use:
 
 When this repository references `architecture-knowledge-toolkit`, treat that
 toolkit as the canonical source for architecture contracts, task skills,
-templates, metamodel schemas, validators, and generators. Project-local
-instructions and contracts still win when they deliberately narrow or override
-the toolkit. For issue implementation, pull request review, ADRs, quality
-scenarios, risks, traceability, and commit messages, use the corresponding
-toolkit `skills/**/SKILL.md` and contract guidance where applicable instead of
+templates, metamodel schemas, validators, generators, and SDLC workflows.
+Project-local instructions and contracts still win when they deliberately
+narrow or override the toolkit. For issue slicing, issue implementation,
+architecture impact analysis, commit messages, pull request review, post-merge
+synchronization, ADRs, quality scenarios, risks, traceability, domain modeling,
+and related architecture maintenance, use the corresponding toolkit
+`skills/**/SKILL.md` and contract guidance where applicable instead of
 recreating those rules locally.
 
 ## Profile Knowledge


### PR DESCRIPTION
## Summary

- Expand repository agent instructions to reference the newer architecture-knowledge-toolkit SDLC skills.
- Clarify that toolkit-provided architecture and SDLC skills are discovered from the toolkit instead of copied locally.
- Update the Codex adapter README to distinguish project-local skills from toolkit-backed workflows.

## Validation

- Reviewed the local diff and confirmed only agent/contract documentation changed.
- No Gradle validation was run because no architecture metadata, profile metadata, generator, or build behavior changed.