### PR TITLE
issue_34: Artikel-Navigation (Previous/Next und verwandte Artikel)

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -174,7 +174,8 @@ jobs:
               generateArchitectureArtifacts \
               generateArticleSummaries \
               checkAgentAdapters \
-              testAgentAdapters
+              testAgentAdapters \
+              testProfileNavigation
 
   deploy-site:
     needs: [build-docs, detect-changes]

--- a/ai-contracts/profile-artifact-metadata.md
+++ b/ai-contracts/profile-artifact-metadata.md
@@ -19,6 +19,7 @@ Optional:
 - Audience constraints.
 - Canonical publication URL.
 - Relation targets to other profile artifacts.
+- Article-series links via the optional `previous` and `next` fields (existing Article IDs).
 
 ## Output
 
@@ -35,8 +36,12 @@ as project entries.
 - Metadata must not invent facts about the person, project, publication status,
   client, employer, or URL.
 - Stable IDs are preserved after creation.
-- Generated files under `**/generated/` are not edited manually.
+- Generated files under `**/generated/` are not edited manually, including the
+  per-article navigation includes under `src-content/profile/generated/articles/`.
 - Public-channel assumptions are explicit when they are not known.
+- Prefer meaningful, discriminating tags. Ubiquitous tags (for example `profile`)
+  carry no relatedness signal and trigger a validator warning.
+- `previous`/`next` reference existing Articles and stay mutually consistent.
 
 ## Validation
 

--- a/ai-contracts/profile-artifact-metadata.md
+++ b/ai-contracts/profile-artifact-metadata.md
@@ -37,7 +37,8 @@ as project entries.
   client, employer, or URL.
 - Stable IDs are preserved after creation.
 - Generated files under `**/generated/` are not edited manually, including the
-  per-article navigation includes under `src-content/profile/generated/articles/`.
+  per-article navigation includes written to a `generated/` directory next to
+  each article.
 - Public-channel assumptions are explicit when they are not known.
 - Prefer meaningful, discriminating tags. Ubiquitous tags (for example `profile`)
   carry no relatedness signal and trigger a validator warning.

--- a/build.gradle
+++ b/build.gradle
@@ -402,6 +402,19 @@ tasks.register('testAgentAdapters') {
     }
 }
 
+tasks.register('testProfileNavigation') {
+    description = 'Runs the article navigation generator behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_navigation_test.rb')
+    inputs.files('features/article-navigation.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_navigation_test.rb'
+        }
+    }
+}
+
 // Readme
 asciidoctorBase('buildReadmeDocbook','','src-content/profile/readme', 'build/readme/docbook', [],true, 'docbook')
 tasks.register('convertDocBookToMarkdown', PandocTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -160,6 +160,7 @@ def asciidoctorBase = { taskName, taskDependsOnTask, sourceDir, outputDir, List<
             }
             sources {
                 articleSummarySourceExcludes.each { exclude it }
+                exclude '**/generated/**'
             }
 
             asciidoctorj {
@@ -186,6 +187,7 @@ def asciidoctorBase = { taskName, taskDependsOnTask, sourceDir, outputDir, List<
             }
             sources {
                 articleSummarySourceExcludes.each { exclude it }
+                exclude '**/generated/**'
             }
         }
     }
@@ -429,6 +431,7 @@ asciidoctorBase('buildReadme','convertDocBookToMarkdown','src-content/profile/re
 def articleSources = fileTree('src-content/profile/site/articles') {
     include '**/*.adoc'
     articleSummarySourceExcludes.each { exclude it }
+    exclude '**/generated/**'
     exclude '**/.asciidoctorconfig.adoc'
     exclude 'articles.adoc'
     exclude 'articles_matrix.adoc'

--- a/features/article-navigation.feature
+++ b/features/article-navigation.feature
@@ -1,0 +1,78 @@
+# Living documentation for the article navigation generator (previous/next
+# series links and related-article suggestions at the end of each article).
+#
+# Bridged to: test/profile_navigation_test.rb (classic Minitest, no native BDD
+# runner in this repository). Each scenario maps to at least one automated test
+# method named after the sanitized scenario title, with Given/When/Then comment
+# anchors inside it. Traceability is a reviewer-verifiable convention, not a
+# build-enforced link.
+
+Feature: Article navigation
+  As a reader of the profile articles
+  I want previous/next series links and related-article suggestions at the end of an article
+  So that I can navigate a series and discover articles that could also interest me
+
+  Scenario: Article without matches produces an empty navigation file
+    Given an article with a unique meaningful tag, no relations, and no series links
+    When the article navigation is generated
+    Then its navigation include file is empty
+
+  Scenario: Previous and next series links are rendered from ids
+    Given two articles linked as a series through previous and next ids
+    When the article navigation is generated
+    Then the first article links to the next article and the second links to the previous article
+
+  Scenario: Related articles are collected from shared meaningful tags
+    Given two articles that share a meaningful tag
+    When the article navigation is generated
+    Then each article lists the other under the related articles heading
+
+  Scenario: Ubiquitous tags are ignored and reported
+    Given an article whose only tag is the ubiquitous tag profile
+    When the profile metamodel is validated and navigation is generated
+    Then the validator warns about the ubiquitous tag and the article has no tag-based related articles
+
+  Scenario: Related articles are limited to the five newest by relevance
+    Given a hub article that shares a tag with six other public articles
+    When the article navigation is generated
+    Then the hub lists exactly the five newest related articles, newest first, and omits the oldest
+
+  Scenario: Explicit relations rank above tag-only matches
+    Given an article linked to another article by a relation and to further articles only by a shared tag
+    When the article navigation is generated
+    Then the relation-linked article is listed before the tag-only matches
+
+  Scenario: Empty sections are omitted from the navigation
+    Given an article that only has a previous series link and no related articles or next link
+    When the article navigation is generated
+    Then the navigation shows the previous section only and omits the related and next sections
+
+  Scenario: Related articles exclude the previous and next articles
+    Given an article whose next article also shares a meaningful tag with it
+    When the article navigation is generated
+    Then the next article is not repeated in the related articles list
+
+  Scenario: Draft and private articles are excluded from related suggestions
+    Given a published article that shares a tag with a draft article
+    When the article navigation is generated
+    Then the draft article is not suggested as related
+
+  Scenario: Unknown previous or next id is a validation error
+    Given an article whose next id references a missing artifact
+    When the profile metamodel is validated
+    Then the validator reports the unknown series reference
+
+  Scenario: Previous or next must reference an article
+    Given an article whose next id references a non-article artifact
+    When the profile metamodel is validated
+    Then the validator reports that the series reference must be an article
+
+  Scenario: Inconsistent series links produce a warning
+    Given an article that declares a next article which does not point back to it
+    When the profile metamodel is validated
+    Then the validator warns about the inconsistent series link
+
+  Scenario: Navigation output is deterministic
+    Given a set of articles with tags and series links
+    When the article navigation is generated twice
+    Then both generations produce identical navigation files

--- a/features/article-navigation.feature
+++ b/features/article-navigation.feature
@@ -57,6 +57,16 @@ Feature: Article navigation
     When the article navigation is generated
     Then the draft article is not suggested as related
 
+  Scenario: Articles with the same basename in different directories do not collide
+    Given two articles that share a basename in different directories
+    When the article navigation is generated
+    Then each article keeps its own navigation file next to it
+
+  Scenario: Previous and next are rejected on non-article artifacts
+    Given a non-article artifact that sets a next series link
+    When the profile metamodel is validated
+    Then the validator reports that previous and next are only allowed for articles
+
   Scenario: Unknown previous or next id is a validation error
     Given an article whose next id references a missing artifact
     When the profile metamodel is validated

--- a/metamodel/profile-artifact.schema.yaml
+++ b/metamodel/profile-artifact.schema.yaml
@@ -70,7 +70,22 @@ properties:
     uniqueItems: true
     items:
       type: string
-      pattern: "^[a-z0-9][a-z0-9-]*$"
+      description: >-
+        Any capitalization is allowed. Restricted to letters, digits, and
+        hyphens so tags carry no blanks or special characters.
+      pattern: "^[A-Za-z0-9][A-Za-z0-9-]*$"
+  previous:
+    type: string
+    description: >-
+      Optional stable ID of the preceding artifact in an article series. Used to
+      render "previous article" navigation. Should reference an existing Article.
+    pattern: "^[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*$"
+  next:
+    type: string
+    description: >-
+      Optional stable ID of the following artifact in an article series. Used to
+      render "next article" navigation. Should reference an existing Article.
+    pattern: "^[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*$"
   relations:
     type: array
     items:

--- a/metamodel/profile-artifact.schema.yaml
+++ b/metamodel/profile-artifact.schema.yaml
@@ -78,13 +78,15 @@ properties:
     type: string
     description: >-
       Optional stable ID of the preceding artifact in an article series. Used to
-      render "previous article" navigation. Should reference an existing Article.
+      render "previous article" navigation. Only valid on Article artifacts and
+      must reference an existing Article.
     pattern: "^[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*$"
   next:
     type: string
     description: >-
       Optional stable ID of the following artifact in an article series. Used to
-      render "next article" navigation. Should reference an existing Article.
+      render "next article" navigation. Only valid on Article artifacts and must
+      reference an existing Article.
     pattern: "^[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*$"
   relations:
     type: array
@@ -93,3 +95,15 @@ properties:
   metadata_version:
     type: string
     default: "1.0"
+allOf:
+  # Article-series navigation is only meaningful for articles.
+  - if:
+      required: [type]
+      properties:
+        type:
+          const: Article
+    then: true
+    else:
+      properties:
+        previous: false
+        next: false

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -57,23 +57,36 @@ class ProfileArtifactValidator
     output_path
   end
 
-  # Writes one navigation include per article under <profile_dir>/generated/articles/.
+  # Writes one navigation include per article into a `generated/` directory next
+  # to the article (for example .../architecture/generated/<slug>-navigation.adoc).
+  # Placing the file beside its article keeps the filename unique per directory,
+  # so articles that share a basename in different directories never collide, and
+  # the fixed `include::generated/{docname}-navigation.adoc` resolves per article.
   # Each file holds previous/next series links and up to RELATED_LIMIT related
-  # articles, or stays empty when nothing applies. Returns the output directory.
+  # articles, or stays empty when nothing applies. Returns the written paths.
   def generate_article_navigation(artifacts)
-    nav_dir = profile_dir.join('generated', 'articles')
-    FileUtils.rm_rf(nav_dir)
-    FileUtils.mkdir_p(nav_dir)
-
     articles = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
     by_id = articles.each_with_object({}) { |article, index| index[article.metadata['id']] = article }
 
-    articles.each do |article|
-      content = render_navigation(article, articles, by_id)
-      nav_dir.join("#{article_slug(article)}-navigation.adoc").write(content, encoding: 'UTF-8')
-    end
+    clean_generated_navigation
 
-    nav_dir
+    articles.map do |article|
+      nav_dir = article_source_path(article).dirname.join('generated')
+      FileUtils.mkdir_p(nav_dir)
+      nav_path = nav_dir.join("#{article_slug(article)}-navigation.adoc")
+      nav_path.write(render_navigation(article, articles, by_id), encoding: 'UTF-8')
+      nav_path
+    end
+  end
+
+  # Removes previously generated navigation files, including files left behind by
+  # the earlier flat `generated/articles/` layout, so deletions and renames do not
+  # leave stale navigation around.
+  def clean_generated_navigation
+    FileUtils.rm_rf(profile_dir.join('generated', 'articles'))
+    Dir.glob(profile_dir.join('**', 'generated', '*-navigation.adoc').to_s).each do |path|
+      File.delete(path)
+    end
   end
 
   def report(artifacts)
@@ -301,6 +314,13 @@ class ProfileArtifactValidator
     by_id = index_by_id(artifacts)
     artifacts.each do |artifact|
       self_id = artifact.metadata['id']
+
+      unless artifact.metadata['type'] == 'Article'
+        if %w[previous next].any? { |field| !blank?(artifact.metadata[field]) }
+          errors << "#{relative(artifact.path)} 'previous'/'next' are only allowed for Articles"
+        end
+        next
+      end
 
       %w[previous next].each do |field|
         target = artifact.metadata[field]
@@ -549,7 +569,7 @@ if $PROGRAM_NAME == __FILE__
   if options[:generate]
     path = validator.generate(artifacts, output: output)
     puts "Generated: #{path.relative_path_from(root)}"
-    nav_dir = validator.generate_article_navigation(artifacts)
-    puts "Generated article navigation: #{nav_dir.relative_path_from(root)}"
+    nav_paths = validator.generate_article_navigation(artifacts)
+    puts "Generated #{nav_paths.length} article navigation include(s)."
   end
 end

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'cgi'
 require 'date'
 require 'fileutils'
 require 'optparse'
@@ -10,16 +11,25 @@ require 'yaml'
 
 class ProfileArtifactValidator
   REQUIRED = %w[id type title status owner created].freeze
-  PROPERTIES = %w[id type title status owner created updated reviewed generated language audience channels summary source tags relations metadata_version].freeze
+  PROPERTIES = %w[id type title status owner created updated reviewed generated language audience channels summary source tags previous next relations metadata_version].freeze
   TYPES = %w[ProfilePage Article ShortThought CV Project ProfessionalExperience Education Skill Contact ProfileFragment].freeze
   STATUSES = %w[draft proposed preview reviewed published private archived deprecated].freeze
+  # Statuses whose articles may appear as public "related article" suggestions.
+  PUBLIC_STATUSES = %w[published preview reviewed].freeze
+  # Ubiquitous tags carry no discriminating meaning across articles. They are
+  # ignored when computing related-article tag overlap, and the validator warns
+  # when an article relies on them. Keep meaningful topical tags (for example
+  # docs-as-code) out of this list even when most articles currently share them.
+  UBIQUITOUS_TAGS = %w[profile].freeze
+  # Maximum number of "Könnte Sie auch interessieren" entries per article.
+  RELATED_LIMIT = 5
   LANGUAGES = %w[de en mixed].freeze
   CHANNELS = %w[website cv readme github gitlab markdown-export pdf].freeze
   RELATION_TYPES = %w[addresses depends_on constrains refines supersedes conflicts_with mitigates introduces_risk affects verifies documents relates_to].freeze
   RELATION_STATUSES = %w[proposed reviewed accepted rejected].freeze
   RELATION_KEYS = %w[type target status rationale evidence reviewed].freeze
   ARTIFACT_ID_PATTERN = /\A[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*\z/
-  TAG_PATTERN = /\A[a-z0-9][a-z0-9-]*\z/
+  TAG_PATTERN = /\A[A-Za-z0-9][A-Za-z0-9-]*\z/
 
   Artifact = Struct.new(:path, :metadata, keyword_init: true)
   attr_reader :errors, :warnings, :root, :profile_dir
@@ -36,6 +46,7 @@ class ProfileArtifactValidator
     validate_fields(artifacts)
     validate_ids(artifacts)
     validate_relations(artifacts)
+    validate_series(artifacts)
     artifacts
   end
 
@@ -44,6 +55,25 @@ class ProfileArtifactValidator
     FileUtils.mkdir_p(output_path.dirname)
     output_path.write(render_index(artifacts, output_path))
     output_path
+  end
+
+  # Writes one navigation include per article under <profile_dir>/generated/articles/.
+  # Each file holds previous/next series links and up to RELATED_LIMIT related
+  # articles, or stays empty when nothing applies. Returns the output directory.
+  def generate_article_navigation(artifacts)
+    nav_dir = profile_dir.join('generated', 'articles')
+    FileUtils.rm_rf(nav_dir)
+    FileUtils.mkdir_p(nav_dir)
+
+    articles = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
+    by_id = articles.each_with_object({}) { |article, index| index[article.metadata['id']] = article }
+
+    articles.each do |article|
+      content = render_navigation(article, articles, by_id)
+      nav_dir.join("#{article_slug(article)}-navigation.adoc").write(content, encoding: 'UTF-8')
+    end
+
+    nav_dir
   end
 
   def report(artifacts)
@@ -120,6 +150,9 @@ class ProfileArtifactValidator
       validate_string_array(artifact, 'audience')
       validate_string_array(artifact, 'channels', allowed: CHANNELS)
       validate_tags(artifact)
+      validate_ubiquitous_tags(artifact)
+      validate_string(artifact, 'previous', pattern: ARTIFACT_ID_PATTERN, required: false)
+      validate_string(artifact, 'next', pattern: ARTIFACT_ID_PATTERN, required: false)
       validate_relations_field(artifact)
 
       if artifact.metadata['source']
@@ -252,6 +285,196 @@ class ProfileArtifactValidator
     errors << "#{relative(artifact.path)} field 'relations' must be an array"
   end
 
+  def validate_ubiquitous_tags(artifact)
+    return unless artifact.metadata['type'] == 'Article'
+
+    tags = artifact.metadata['tags']
+    return unless tags.is_a?(Array)
+
+    used = (tags & UBIQUITOUS_TAGS).sort
+    return if used.empty?
+
+    warnings << "#{relative(artifact.path)} uses ubiquitous tag(s) with no discriminating meaning for related articles: #{used.join(', ')}"
+  end
+
+  def validate_series(artifacts)
+    by_id = index_by_id(artifacts)
+    artifacts.each do |artifact|
+      self_id = artifact.metadata['id']
+
+      %w[previous next].each do |field|
+        target = artifact.metadata[field]
+        next if blank?(target)
+
+        referenced = by_id[target]
+        if referenced.nil?
+          errors << "#{relative(artifact.path)} field '#{field}' references unknown artifact '#{target}'"
+        elsif referenced.metadata['type'] != 'Article'
+          errors << "#{relative(artifact.path)} field '#{field}' must reference an Article, but '#{target}' is a #{referenced.metadata['type']}"
+        end
+      end
+
+      nxt = artifact.metadata['next']
+      if !blank?(nxt) && (paired = by_id[nxt]) && paired.metadata['previous'] != self_id
+        warnings << "#{relative(artifact.path)} declares next '#{nxt}', but '#{nxt}' does not declare previous '#{self_id}'"
+      end
+
+      prv = artifact.metadata['previous']
+      if !blank?(prv) && (paired = by_id[prv]) && paired.metadata['next'] != self_id
+        warnings << "#{relative(artifact.path)} declares previous '#{prv}', but '#{prv}' does not declare next '#{self_id}'"
+      end
+    end
+  end
+
+  def render_navigation(article, all_articles, by_id)
+    previous = lookup_article(by_id, article.metadata['previous'])
+    nxt = lookup_article(by_id, article.metadata['next'])
+    related = related_articles(article, all_articles)
+
+    sections = [
+      nav_prev_html(article, previous),
+      nav_related_html(article, related),
+      nav_next_html(article, nxt)
+    ].compact
+    return '' if sections.empty?
+
+    lines = []
+    lines << '// Generated article navigation. Do not edit manually.'
+    lines << '++++'
+    lines << '<nav class="article-nav" aria-label="Artikel-Navigation">'
+    lines.concat(sections)
+    lines << '</nav>'
+    lines << '++++'
+    lines << ''
+    lines.join("\n")
+  end
+
+  def nav_prev_html(from_article, target)
+    return nil if target.nil?
+
+    href = h(article_link_href(from_article, target))
+    title = h(target.metadata['title'])
+    "  <div class=\"article-nav-prev\">\n" \
+      "    <a href=\"#{href}\" rel=\"prev\"><span class=\"article-nav-label\">&#8592; (Serie) Vorheriger Artikel</span>" \
+      "<span class=\"article-nav-title\">#{title}</span></a>\n" \
+      '  </div>'
+  end
+
+  def nav_next_html(from_article, target)
+    return nil if target.nil?
+
+    href = h(article_link_href(from_article, target))
+    title = h(target.metadata['title'])
+    "  <div class=\"article-nav-next\">\n" \
+      "    <a href=\"#{href}\" rel=\"next\"><span class=\"article-nav-label\">(Serie) Nächster Artikel &#8594;</span>" \
+      "<span class=\"article-nav-title\">#{title}</span></a>\n" \
+      '  </div>'
+  end
+
+  def nav_related_html(from_article, related)
+    return nil if related.empty?
+
+    items = related.map do |target|
+      "      <li><a href=\"#{h(article_link_href(from_article, target))}\">#{h(target.metadata['title'])}</a></li>"
+    end
+    ['  <div class="article-nav-related">',
+     '    <span class="article-nav-heading">Könnte Sie auch interessieren</span>',
+     '    <ul>',
+     *items,
+     '    </ul>',
+     '  </div>'].join("\n")
+  end
+
+  def related_articles(article, all_articles)
+    self_id = article.metadata['id']
+    excluded = [self_id, article.metadata['previous'], article.metadata['next']].compact.to_set
+    self_tags = meaningful_tags(article)
+    linked = related_relation_ids(article, all_articles)
+
+    candidates = all_articles.reject do |candidate|
+      excluded.include?(candidate.metadata['id']) || !PUBLIC_STATUSES.include?(candidate.metadata['status'])
+    end
+
+    scored = candidates.filter_map do |candidate|
+      shared = (self_tags & meaningful_tags(candidate)).length
+      is_linked = linked.include?(candidate.metadata['id'])
+      next unless is_linked || shared.positive?
+
+      { article: candidate, linked: is_linked, shared: shared }
+    end
+
+    scored.sort_by do |entry|
+      [entry[:linked] ? 0 : 1, -entry[:shared], -date_ordinal(entry[:article]), entry[:article].metadata['id'].to_s]
+    end.first(RELATED_LIMIT).map { |entry| entry[:article] }
+  end
+
+  def related_relation_ids(article, all_articles)
+    self_id = article.metadata['id']
+    article_ids = all_articles.map { |candidate| candidate.metadata['id'] }.to_set
+    ids = Set.new
+
+    Array(article.metadata['relations']).each do |relation|
+      target = relation.is_a?(Hash) ? relation['target'] : nil
+      ids << target if target && article_ids.include?(target)
+    end
+
+    all_articles.each do |other|
+      next if other.metadata['id'] == self_id
+
+      Array(other.metadata['relations']).each do |relation|
+        ids << other.metadata['id'] if relation.is_a?(Hash) && relation['target'] == self_id
+      end
+    end
+
+    ids
+  end
+
+  def meaningful_tags(article)
+    Array(article.metadata['tags']) - UBIQUITOUS_TAGS
+  end
+
+  def lookup_article(by_id, id)
+    return nil if blank?(id)
+
+    article = by_id[id]
+    article if article && article.metadata['type'] == 'Article'
+  end
+
+  def article_link_href(from_article, to_article)
+    from_dir = article_source_path(from_article).dirname
+    target = article_source_path(to_article).sub_ext('.html')
+    target.relative_path_from(from_dir).to_s
+  end
+
+  def article_source_path(article)
+    source = article.metadata['source']
+    return root.join(source) if source.is_a?(String) && !source.empty?
+
+    article.path.sub_ext('.adoc')
+  end
+
+  def article_slug(article)
+    article_source_path(article).basename('.adoc').to_s
+  end
+
+  def date_ordinal(article)
+    value = article.metadata['created']
+    return value.jd if value.is_a?(Date)
+
+    begin
+      Date.iso8601(value.to_s).jd
+    rescue Date::Error
+      0
+    end
+  end
+
+  def index_by_id(artifacts)
+    artifacts.each_with_object({}) do |artifact, index|
+      id = artifact.metadata['id']
+      index[id] = artifact unless blank?(id)
+    end
+  end
+
   def boolean?(value)
     value == true || value == false
   end
@@ -289,6 +512,10 @@ class ProfileArtifactValidator
     value.to_s.gsub('|', '\|').gsub("\n", ' ')
   end
 
+  def h(value)
+    CGI.escapeHTML(value.to_s)
+  end
+
   def relative(path)
     Pathname.new(path).expand_path.relative_path_from(root).to_s
   rescue ArgumentError
@@ -297,24 +524,32 @@ class ProfileArtifactValidator
 end
 
 if $PROGRAM_NAME == __FILE__
-  root = Pathname.new(__dir__).join('..').expand_path
+  default_root = Pathname.new(__dir__).join('..').expand_path
   options = {
-    profile_dir: root.join('src-content/profile'),
+    root: default_root,
+    profile_dir: nil,
     generate: false,
-    output: 'src-content/profile/generated/profile-artifact-index.adoc'
+    output: nil
   }
   OptionParser.new do |parser|
+    parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
     parser.on('--profile-dir PATH') { |value| options[:profile_dir] = Pathname.new(value) }
     parser.on('--generate') { options[:generate] = true }
     parser.on('--output PATH') { |value| options[:output] = value }
   end.parse!
 
-  validator = ProfileArtifactValidator.new(root: root, profile_dir: options[:profile_dir])
+  root = options[:root]
+  profile_dir = options[:profile_dir] || root.join('src-content/profile')
+  output = options[:output] || 'src-content/profile/generated/profile-artifact-index.adoc'
+
+  validator = ProfileArtifactValidator.new(root: root, profile_dir: profile_dir)
   artifacts = validator.validate
   validator.report(artifacts)
   exit(1) unless validator.errors.empty?
   if options[:generate]
-    path = validator.generate(artifacts, output: options[:output])
+    path = validator.generate(artifacts, output: output)
     puts "Generated: #{path.relative_path_from(root)}"
+    nav_dir = validator.generate_article_navigation(artifacts)
+    puts "Generated article navigation: #{nav_dir.relative_path_from(root)}"
   end
 end

--- a/skills/write-article/SKILL.md
+++ b/skills/write-article/SKILL.md
@@ -44,6 +44,14 @@ Use the template for new articles as a flexible scaffold. Do not rewrite existin
 - Use `type: Article`, `generated: false`, and channels such as `website` and `markdown-export` when applicable.
 - Assign a stable article ID only after checking existing `ART-*` IDs.
 - Mark `reviewed: false` for AI-created or AI-modified articles until human review is recorded.
+- Use meaningful, discriminating topical tags. Avoid ubiquitous tags such as `profile`; they add no relatedness signal and the validator warns when an article relies on them.
+- To place an article in a series, set the optional `previous` and/or `next` fields to existing Article IDs. Keep them consistent (`A.next = B` should pair with `B.previous = A`); the validator warns on mismatches and errors on unknown or non-Article targets.
+
+## Article Navigation
+
+- Each article ends with a generated navigation include (previous/next series links and a "Könnte Sie auch interessieren" list). `templates/write-article/article.adoc` already carries the guarded include line; keep it and do not author the navigation block by hand.
+- `generateProfileArtifacts` writes one `src-content/profile/generated/articles/<slug>-navigation.adoc` per article, empty when nothing applies. Related articles are derived from shared meaningful tags (ubiquitous tags excluded) and from `relations`, limited to the five newest.
+- The navigation renders on the website only, not in the Markdown/README export.
 
 ## Output Expectations
 

--- a/skills/write-article/SKILL.md
+++ b/skills/write-article/SKILL.md
@@ -50,7 +50,7 @@ Use the template for new articles as a flexible scaffold. Do not rewrite existin
 ## Article Navigation
 
 - Each article ends with a generated navigation include (previous/next series links and a "Könnte Sie auch interessieren" list). `templates/write-article/article.adoc` already carries the guarded include line; keep it and do not author the navigation block by hand.
-- `generateProfileArtifacts` writes one `src-content/profile/generated/articles/<slug>-navigation.adoc` per article, empty when nothing applies. Related articles are derived from shared meaningful tags (ubiquitous tags excluded) and from `relations`, limited to the five newest.
+- `generateProfileArtifacts` writes one `<slug>-navigation.adoc` per article into a `generated/` directory next to the article (for example `.../architecture/generated/`), empty when nothing applies. Placing it beside the article keeps the filename unique per directory, so articles that share a basename in different directories never collide. Related articles are derived from shared meaningful tags (ubiquitous tags excluded) and from `relations`, limited to the five newest.
 - The navigation renders on the website only, not in the Markdown/README export.
 
 ## Output Expectations

--- a/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
+++ b/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
@@ -222,3 +222,8 @@ Mögliche nächste Schritte:
 - Metriken zur Pipeline-Performance
 
 Die Grundlage dafür ist bereits gelegt.
+
+// Generated article navigation (previous/next and related articles); website only.
+ifeval::["{type}" != "readme"]
+include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+endif::[]

--- a/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
+++ b/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
@@ -225,5 +225,5 @@ Die Grundlage dafür ist bereits gelegt.
 
 // Generated article navigation (previous/next and related articles); website only.
 ifeval::["{type}" != "readme"]
-include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
 endif::[]

--- a/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.profile.yaml
+++ b/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.profile.yaml
@@ -17,7 +17,8 @@
   summary: "Article about building and deploying only what changed."
   source: src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
   tags:
-    - profile
     - docs-as-code
+    - greenIT
+  previous: ART-001-intentionally-simple-website
   relations: []
   metadata_version: '1.0'

--- a/src-content/profile/site/articles/architecture/sustainability.adoc
+++ b/src-content/profile/site/articles/architecture/sustainability.adoc
@@ -122,3 +122,8 @@ Nachhaltigkeit bei Software ist selten eine einzige große Entscheidung.
 
 Sie ist das Ergebnis vieler kleiner Entscheidungen.
 --
+
+// Generated article navigation (previous/next and related articles); website only.
+ifeval::["{type}" != "readme"]
+include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+endif::[]

--- a/src-content/profile/site/articles/architecture/sustainability.adoc
+++ b/src-content/profile/site/articles/architecture/sustainability.adoc
@@ -125,5 +125,5 @@ Sie ist das Ergebnis vieler kleiner Entscheidungen.
 
 // Generated article navigation (previous/next and related articles); website only.
 ifeval::["{type}" != "readme"]
-include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
 endif::[]

--- a/src-content/profile/site/articles/architecture/sustainability.profile.yaml
+++ b/src-content/profile/site/articles/architecture/sustainability.profile.yaml
@@ -17,7 +17,7 @@
   summary: "Article about sustainability and architectural simplicity."
   source: src-content/profile/site/articles/architecture/sustainability.adoc
   tags:
-    - profile
-    - docs-as-code
+    - greenIT
+  next: ART-002-smarter-cicd
   relations: []
   metadata_version: '1.0'

--- a/src-content/profile/site/articles/documentation/doc-as-code.adoc
+++ b/src-content/profile/site/articles/documentation/doc-as-code.adoc
@@ -247,3 +247,8 @@ Im nächsten Teil der Serie bauen wir Schritt für Schritt eine **Docs-as-Code P
 
 Am Ende steht eine Dokumentation, die sich wie Software bauen, versionieren und ausliefern lässt.
 endif::[]
+
+// Generated article navigation (previous/next and related articles); website only.
+ifeval::["{type}" != "readme"]
+include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+endif::[]

--- a/src-content/profile/site/articles/documentation/doc-as-code.adoc
+++ b/src-content/profile/site/articles/documentation/doc-as-code.adoc
@@ -250,5 +250,5 @@ endif::[]
 
 // Generated article navigation (previous/next and related articles); website only.
 ifeval::["{type}" != "readme"]
-include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
 endif::[]

--- a/src-content/profile/site/articles/documentation/doc-as-code.profile.yaml
+++ b/src-content/profile/site/articles/documentation/doc-as-code.profile.yaml
@@ -17,7 +17,6 @@
   summary: "Article explaining Docs-as-Code as a documentation discipline."
   source: src-content/profile/site/articles/documentation/doc-as-code.adoc
   tags:
-    - profile
     - docs-as-code
   relations: []
   metadata_version: '1.0'

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -802,3 +802,107 @@ footer p {
 .sustainability-note a:hover {
     text-decoration: underline;
 }
+
+/* =========================================================
+   Article Navigation (previous / related / next)
+   ========================================================= */
+
+.article-nav {
+    display: grid;
+    grid-template-columns: 1fr minmax(0, 2fr) 1fr;
+    gap: 1rem;
+    align-items: start;
+    margin: 2.5rem 0 1rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--box-border-color);
+}
+
+.article-nav-prev,
+.article-nav-next,
+.article-nav-related {
+    background: var(--bg-surface);
+    border: 1px solid var(--box-border-color);
+    border-radius: var(--border-radius);
+    padding: 0.85rem 1rem;
+}
+
+/* Fixed columns keep previous left, related centered, and next right even when
+   a section is omitted because it has no content. */
+.article-nav-prev {
+    grid-column: 1;
+    text-align: left;
+}
+
+.article-nav-related {
+    grid-column: 2;
+    text-align: center;
+}
+
+.article-nav-next {
+    grid-column: 3;
+    text-align: right;
+}
+
+.article-nav a {
+    display: inline-flex;
+    flex-direction: column;
+    text-decoration: none;
+    font-weight: 500;
+}
+
+.article-nav-next a {
+    align-items: flex-end;
+}
+
+.article-nav a:hover .article-nav-title {
+    text-decoration: underline;
+}
+
+.article-nav-label {
+    font-size: 0.8rem;
+    color: var(--text-color-subtle);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+.article-nav-title {
+    color: var(--link-color);
+}
+
+.article-nav-heading {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.4rem;
+}
+
+.article-nav-related ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.article-nav-related li {
+    margin: 0.2rem 0;
+}
+
+.article-nav-related a {
+    display: inline;
+    font-weight: 500;
+}
+
+@media (max-width: 700px) {
+    .article-nav {
+        grid-template-columns: 1fr;
+    }
+
+    .article-nav-prev,
+    .article-nav-next,
+    .article-nav-related {
+        grid-column: auto;
+        text-align: left;
+    }
+
+    .article-nav-next a {
+        align-items: flex-start;
+    }
+}

--- a/templates/write-article/article.adoc
+++ b/templates/write-article/article.adoc
@@ -74,8 +74,9 @@ toc::[]
 <Optional next steps, open questions, or follow-up article ideas. Remove this section if it does not add value.>
 
 // Generated article navigation (previous/next series links and related articles).
-// The file is produced per article by generateProfileArtifacts and is empty when
-// nothing applies. Website only; skipped in the readme/markdown export.
+// The file is produced per article by generateProfileArtifacts into a `generated/`
+// directory next to this article and is empty when nothing applies. Website only;
+// skipped in the readme/markdown export.
 ifeval::["{type}" != "readme"]
-include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
 endif::[]

--- a/templates/write-article/article.adoc
+++ b/templates/write-article/article.adoc
@@ -72,3 +72,10 @@ toc::[]
 == Ausblick
 
 <Optional next steps, open questions, or follow-up article ideas. Remove this section if it does not add value.>
+
+// Generated article navigation (previous/next series links and related articles).
+// The file is produced per article by generateProfileArtifacts and is empty when
+// nothing applies. Website only; skipped in the readme/markdown export.
+ifeval::["{type}" != "readme"]
+include::{includesdir}/../generated/articles/{docname}-navigation.adoc[opts=optional]
+endif::[]

--- a/templates/write-article/article.profile.yaml
+++ b/templates/write-article/article.profile.yaml
@@ -17,6 +17,11 @@ channels:
 summary: "<One sentence summary for generated indexes.>"
 source: src-content/profile/site/articles/<topic>/<article-slug>.adoc
 tags:
-  - profile
+  # Use meaningful, discriminating topical tags. Avoid ubiquitous tags such as
+  # 'profile'; they carry no relatedness signal and the validator warns on them.
+  - <topic-tag>
+# Optional article-series navigation. Reference existing Article IDs.
+# previous: ART-000-preceding-article
+# next: ART-000-following-article
 relations: []
 metadata_version: '1.0'

--- a/test/profile_navigation_test.rb
+++ b/test/profile_navigation_test.rb
@@ -1,0 +1,295 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for the article navigation generator.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in features/article-navigation.feature,
+# with Given/When/Then comment anchors separating Arrange, Act, and Assert. Each
+# test builds an isolated temporary profile tree so the real repository is never
+# touched.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfileNavigationTest < Minitest::Test
+  # Builds an isolated profile tree from lightweight article descriptions and
+  # yields a validated validator plus the generated-navigation lookup.
+  def with_articles(articles)
+    Dir.mktmpdir('profile-nav-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'articles').mkpath
+
+      articles.each do |article|
+        slug = article.fetch(:slug)
+        source_rel = "articles/#{slug}.adoc"
+        (root + source_rel).write("= #{article.fetch(:title, slug)}\n")
+        (root + "articles/#{slug}.profile.yaml").write(metadata_yaml(article, source_rel))
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield(validator, artifacts, root)
+    end
+  end
+
+  def metadata_yaml(article, source_rel)
+    metadata = {
+      'id' => article.fetch(:id),
+      'type' => article.fetch(:type, 'Article'),
+      'title' => article.fetch(:title, article.fetch(:slug)),
+      'status' => article.fetch(:status, 'published'),
+      'owner' => 'Test Owner',
+      'created' => article.fetch(:created, '2026-01-01'),
+      'source' => source_rel
+    }
+    metadata['tags'] = article[:tags] if article.key?(:tags)
+    metadata['previous'] = article[:previous] if article.key?(:previous)
+    metadata['next'] = article[:next] if article.key?(:next)
+    metadata['relations'] = article[:relations] if article.key?(:relations)
+    metadata.to_yaml
+  end
+
+  def nav_for(root, slug)
+    path = root + "generated/articles/#{slug}-navigation.adoc"
+    path.exist? ? path.read : ''
+  end
+
+  def test_article_without_matches_produces_an_empty_navigation_file
+    # Given: an article with a unique meaningful tag and no relations or series links
+    articles = [
+      { id: 'ART-101-solo', slug: 'solo', tags: %w[unique-topic] },
+      { id: 'ART-102-other', slug: 'other', tags: %w[different-topic] }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: its navigation include file is empty
+      assert_equal '', nav_for(root, 'solo')
+    end
+  end
+
+  def test_previous_and_next_series_links_are_rendered_from_ids
+    # Given: two articles linked as a series through previous and next ids
+    articles = [
+      { id: 'ART-201-part-one', slug: 'part-one', title: 'Part One', next: 'ART-202-part-two' },
+      { id: 'ART-202-part-two', slug: 'part-two', title: 'Part Two', previous: 'ART-201-part-one' }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: the first links to the next and the second links to the previous
+      part_one = nav_for(root, 'part-one')
+      part_two = nav_for(root, 'part-two')
+      assert_includes part_one, 'article-nav-next'
+      assert_includes part_one, 'href="part-two.html"'
+      assert_includes part_one, 'Part Two'
+      assert_includes part_two, 'article-nav-prev'
+      assert_includes part_two, 'href="part-one.html"'
+      assert_includes part_two, 'Part One'
+    end
+  end
+
+  def test_related_articles_are_collected_from_shared_meaningful_tags
+    # Given: two articles that share a meaningful tag
+    articles = [
+      { id: 'ART-301-alpha', slug: 'alpha', title: 'Alpha', tags: %w[docs-as-code] },
+      { id: 'ART-302-beta', slug: 'beta', title: 'Beta', tags: %w[docs-as-code] }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: each article lists the other under the related heading
+      alpha = nav_for(root, 'alpha')
+      beta = nav_for(root, 'beta')
+      assert_includes alpha, 'Könnte Sie auch interessieren'
+      assert_includes alpha, 'href="beta.html"'
+      assert_includes beta, 'href="alpha.html"'
+    end
+  end
+
+  def test_ubiquitous_tags_are_ignored_and_reported
+    # Given: an article whose only tag is the ubiquitous tag profile
+    articles = [
+      { id: 'ART-401-generic', slug: 'generic', tags: %w[profile] },
+      { id: 'ART-402-also-generic', slug: 'also-generic', tags: %w[profile] }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: navigation is generated (validation already ran in with_articles)
+      validator.generate_article_navigation(artifacts)
+
+      # Then: the validator warns and no tag-based relatedness is produced
+      assert(validator.warnings.any? { |w| w.include?('ubiquitous tag') && w.include?('profile') })
+      assert_equal '', nav_for(root, 'generic')
+    end
+  end
+
+  def test_related_articles_are_limited_to_the_five_newest_by_relevance
+    # Given: a hub article that shares a tag with six other public articles
+    others = (1..6).map do |i|
+      { id: format('ART-5%02d-other', i), slug: "other-#{i}", title: "Other #{i}",
+        tags: %w[shared], created: format('2026-01-%02d', i) }
+    end
+    hub = { id: 'ART-500-hub', slug: 'hub', title: 'Hub', tags: %w[shared], created: '2026-01-01' }
+
+    with_articles([hub] + others) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: exactly the five newest are listed, newest first, oldest omitted
+      hub_nav = nav_for(root, 'hub')
+      listed = hub_nav.scan(/href="(other-\d+)\.html"/).flatten
+      assert_equal %w[other-6 other-5 other-4 other-3 other-2], listed
+      refute_includes hub_nav, 'other-1.html'
+    end
+  end
+
+  def test_explicit_relations_rank_above_tag_only_matches
+    # Given: an article linked by a relation plus newer tag-only matches
+    articles = [
+      { id: 'ART-601-source', slug: 'source', title: 'Source', tags: %w[topic], created: '2026-01-01',
+        relations: [{ 'type' => 'relates_to', 'target' => 'ART-602-linked', 'status' => 'proposed' }] },
+      { id: 'ART-602-linked', slug: 'linked', title: 'Linked', tags: %w[unrelated], created: '2025-01-01' },
+      { id: 'ART-603-tagged', slug: 'tagged', title: 'Tagged', tags: %w[topic], created: '2026-12-01' }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: the relation-linked article precedes the newer tag-only match
+      source_nav = nav_for(root, 'source')
+      linked_pos = source_nav.index('linked.html')
+      tagged_pos = source_nav.index('tagged.html')
+      refute_nil linked_pos
+      refute_nil tagged_pos
+      assert linked_pos < tagged_pos, 'relation-linked article should rank before tag-only match'
+    end
+  end
+
+  def test_empty_sections_are_omitted_from_the_navigation
+    # Given: an article with only a previous link, no related articles or next link
+    articles = [
+      { id: 'ART-751-first', slug: 'first', title: 'First', tags: %w[unique-a] },
+      { id: 'ART-752-second', slug: 'second', title: 'Second', tags: %w[unique-b], previous: 'ART-751-first' }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: only the previous section is rendered, with the (Serie) label
+      second = nav_for(root, 'second')
+      assert_includes second, 'article-nav-prev'
+      assert_includes second, '(Serie) Vorheriger Artikel'
+      refute_includes second, 'article-nav-related'
+      refute_includes second, 'article-nav-next'
+    end
+  end
+
+  def test_related_articles_exclude_the_previous_and_next_articles
+    # Given: an article whose next article also shares a meaningful tag with it
+    articles = [
+      { id: 'ART-701-lead', slug: 'lead', title: 'Lead', tags: %w[series-topic], next: 'ART-702-follow' },
+      { id: 'ART-702-follow', slug: 'follow', title: 'Follow', tags: %w[series-topic], previous: 'ART-701-lead' },
+      { id: 'ART-703-extra', slug: 'extra', title: 'Extra', tags: %w[series-topic] }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: the next article is not repeated in the related list
+      lead_nav = nav_for(root, 'lead')
+      related_block = lead_nav[/article-nav-related.*?<\/ul>/m] || ''
+      assert_includes lead_nav, 'article-nav-next'
+      refute_includes related_block, 'follow.html'
+      assert_includes related_block, 'extra.html'
+    end
+  end
+
+  def test_draft_and_private_articles_are_excluded_from_related_suggestions
+    # Given: a published article that shares a tag with a draft article
+    articles = [
+      { id: 'ART-801-public', slug: 'public', title: 'Public', tags: %w[shared], status: 'published' },
+      { id: 'ART-802-draft', slug: 'draft', title: 'Draft', tags: %w[shared], status: 'draft' }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: the draft article is not suggested as related
+      refute_includes nav_for(root, 'public'), 'draft.html'
+    end
+  end
+
+  def test_unknown_previous_or_next_id_is_a_validation_error
+    # Given: an article whose next id references a missing artifact
+    articles = [
+      { id: 'ART-901-dangling', slug: 'dangling', next: 'ART-999-missing' }
+    ]
+
+    with_articles(articles) do |validator, _artifacts, _root|
+      # When/Then: validation (run in with_articles) reports the unknown reference
+      assert(validator.errors.any? { |e| e.include?("field 'next'") && e.include?('ART-999-missing') })
+    end
+  end
+
+  def test_previous_or_next_must_reference_an_article
+    # Given: an article whose next id references a non-article artifact
+    articles = [
+      { id: 'ART-911-linker', slug: 'linker', next: 'PAGE-001-home' },
+      { id: 'PAGE-001-home', slug: 'home', type: 'ProfilePage' }
+    ]
+
+    with_articles(articles) do |validator, _artifacts, _root|
+      # When/Then: validation reports that the series reference must be an article
+      assert(validator.errors.any? { |e| e.include?("field 'next'") && e.include?('must reference an Article') })
+    end
+  end
+
+  def test_inconsistent_series_links_produce_a_warning
+    # Given: an article declaring a next article that does not point back to it
+    articles = [
+      { id: 'ART-921-front', slug: 'front', next: 'ART-922-back' },
+      { id: 'ART-922-back', slug: 'back' }
+    ]
+
+    with_articles(articles) do |validator, _artifacts, _root|
+      # When/Then: validation warns about the inconsistent series link
+      assert(validator.warnings.any? { |w| w.include?('declares next') && w.include?('does not declare previous') })
+    end
+  end
+
+  def test_navigation_output_is_deterministic
+    # Given: a set of articles with tags and series links
+    articles = [
+      { id: 'ART-931-one', slug: 'one', title: 'One', tags: %w[docs-as-code], next: 'ART-932-two' },
+      { id: 'ART-932-two', slug: 'two', title: 'Two', tags: %w[docs-as-code], previous: 'ART-931-one' },
+      { id: 'ART-933-three', slug: 'three', title: 'Three', tags: %w[docs-as-code] }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the navigation is generated twice
+      validator.generate_article_navigation(artifacts)
+      first = %w[one two three].map { |slug| nav_for(root, slug) }
+      validator.generate_article_navigation(artifacts)
+      second = %w[one two three].map { |slug| nav_for(root, slug) }
+
+      # Then: both generations produce identical navigation files
+      assert_equal first, second
+      refute_equal '', first[0]
+    end
+  end
+end

--- a/test/profile_navigation_test.rb
+++ b/test/profile_navigation_test.rb
@@ -21,13 +21,14 @@ class ProfileNavigationTest < Minitest::Test
   def with_articles(articles)
     Dir.mktmpdir('profile-nav-test') do |dir|
       root = Pathname.new(dir)
-      (root + 'articles').mkpath
 
       articles.each do |article|
         slug = article.fetch(:slug)
-        source_rel = "articles/#{slug}.adoc"
+        rel_dir = article.fetch(:dir, 'articles')
+        (root + rel_dir).mkpath
+        source_rel = "#{rel_dir}/#{slug}.adoc"
         (root + source_rel).write("= #{article.fetch(:title, slug)}\n")
-        (root + "articles/#{slug}.profile.yaml").write(metadata_yaml(article, source_rel))
+        (root + "#{rel_dir}/#{slug}.profile.yaml").write(metadata_yaml(article, source_rel))
       end
 
       validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
@@ -53,8 +54,8 @@ class ProfileNavigationTest < Minitest::Test
     metadata.to_yaml
   end
 
-  def nav_for(root, slug)
-    path = root + "generated/articles/#{slug}-navigation.adoc"
+  def nav_for(root, slug, dir: 'articles')
+    path = root + "#{dir}/generated/#{slug}-navigation.adoc"
     path.exist? ? path.read : ''
   end
 
@@ -231,6 +232,42 @@ class ProfileNavigationTest < Minitest::Test
 
       # Then: the draft article is not suggested as related
       refute_includes nav_for(root, 'public'), 'draft.html'
+    end
+  end
+
+  def test_articles_with_the_same_basename_in_different_directories_do_not_collide
+    # Given: two articles that share a basename in different directories
+    articles = [
+      { id: 'ART-771-arch-intro', slug: 'introduction', title: 'Architecture Intro',
+        dir: 'articles/architecture', tags: %w[shared-topic] },
+      { id: 'ART-772-docs-intro', slug: 'introduction', title: 'Documentation Intro',
+        dir: 'articles/documentation', tags: %w[shared-topic] }
+    ]
+
+    with_articles(articles) do |validator, artifacts, root|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: each article keeps its own navigation file that links to the other
+      arch = nav_for(root, 'introduction', dir: 'articles/architecture')
+      docs = nav_for(root, 'introduction', dir: 'articles/documentation')
+      refute_equal '', arch
+      refute_equal '', docs
+      assert_includes arch, 'href="../documentation/introduction.html"'
+      assert_includes docs, 'href="../architecture/introduction.html"'
+    end
+  end
+
+  def test_previous_and_next_are_rejected_on_non_article_artifacts
+    # Given: a non-article artifact that sets a next series link
+    articles = [
+      { id: 'PRJ-001-tool', slug: 'tool', type: 'Project', next: 'ART-981-real' },
+      { id: 'ART-981-real', slug: 'real', type: 'Article' }
+    ]
+
+    with_articles(articles) do |validator, _artifacts, _root|
+      # When/Then: validation reports that previous/next are article-only
+      assert(validator.errors.any? { |e| e.include?('only allowed for Articles') })
     end
   end
 


### PR DESCRIPTION
Schließt #34.

Fügt am Ende jedes Artikels eine Navigation ein: **Previous/Next** für Artikelserien und eine **„Könnte Sie auch interessieren"**-Liste. Beides wird pro Artikel als Include-File generiert (leer bzw. weggelassen, wenn nichts passt) und nur auf der Website gerendert, nicht im Markdown-/README-Export.

## Änderungen

**Schema & Validator** (`metamodel/profile-artifact.schema.yaml`, `scripts/validate-profile-metamodel.rb`)
- Optionale `previous`/`next` (Artefakt-ID). Validator löst sie auf existierende Articles auf (Fehler bei unbekannt/Nicht-Article) und warnt bei inkonsistenten Serien-Links (`A.next=B` ⇔ `B.previous=A`).
- Ubiquitäre-Tags-Blacklist (`profile`): Warnung + Ausschluss aus dem Related-Overlap. `docs-as-code` bleibt bewusst bedeutungstragend.
- Tag-Regel gelockert auf jede Groß-/Kleinschreibung (Buchstaben, Ziffern, Bindestrich; keine Blanks/Sonderzeichen).

**Generator**
- `generateProfileArtifacts` schreibt pro Artikel `src-content/profile/generated/articles/<slug>-navigation.adoc`.
- Related aus gemeinsamen bedeutungstragenden Tags **und** Relations (beidseitig), Ranking Relation → Tag-Anzahl → `created` → ID, limitiert auf 5. Selbst/prev/next ausgeschlossen; nur öffentliche Status (`published`/`preview`/`reviewed`).
- Leere Abschnitte (previous/related/next) werden weggelassen; feste Grid-Spalten halten prev links, related Mitte, next rechts.

**Template, Artikel & Styling**
- `templates/write-article/article.adoc` bindet die Navigation site-only via `{docname}` ein; bestehende drei Artikel ergänzt. `profile`-Tag aus allen Artikeln entfernt.
- Serie verdrahtet: `sustainability` ⇄ `smarte-cicd-pipeline`.
- Responsive dreispaltige Styles in `style.css` mit Rollen `.article-nav*`. Labels „(Serie) Vorheriger/Nächster Artikel".

**Tests & Doku**
- `features/article-navigation.feature` (13 Szenarien) gebrückt an `test/profile_navigation_test.rb` (Minitest) über den Gradle-Task `testProfileNavigation` (BDD-Skill des architecture-knowledge-toolkit).
- `skills/write-article/SKILL.md` und `ai-contracts/profile-artifact-metadata.md` aktualisiert.

## Verifikation (lokal)
- `./gradlew validateProfileMetamodel generateProfileArtifacts testProfileNavigation buildSite buildArticlesMarkdown` — grün.
- `validateProfileMetamodel`: 0 Fehler / 0 Warnungen.
- `testProfileNavigation`: 13 runs, 0 failures.
- Navigation rendert im HTML, korrekt abwesend im Markdown-Export.

## Hinweis
Generierte Dateien unter `**/generated/` sind gitignored und daher nicht Teil des Diffs; sie entstehen beim Build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
