### PR TITLE
issue_39: CI-Pipeline über build.sh ausführen

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -79,13 +79,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set image
-        id: set_image
-        run: echo "IMAGE_NAME=ghcr.io/docs-as-code-toolkit/docs-toolbox:v1.3.1" >> $GITHUB_OUTPUT
-
-      - name: Pull runtime image
-        run: docker pull ${{ steps.set_image.outputs.IMAGE_NAME }}
-
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -95,48 +88,40 @@ jobs:
       - name: Run build
         id: run_build
         run: |
-          CMD="./gradlew --no-daemon"
+          TASKS=""
 
           if [ "${{ needs.detect-changes.outputs.readme }}" == "true" ]; then
-            CMD="$CMD buildReadme"
+            TASKS="$TASKS buildReadme"
           fi
 
           if [ "${{ needs.detect-changes.outputs.articles }}" == "true" ]; then
-            CMD="$CMD buildArticlesMarkdown"
+            TASKS="$TASKS buildArticlesMarkdown"
           fi
 
           if [ "${{ needs.detect-changes.outputs.architecture }}" == "true" ]; then
-            CMD="$CMD buildArchitecture"
+            TASKS="$TASKS buildArchitecture"
           fi
-          
+
           if [ "${{ needs.detect-changes.outputs.site }}" == "true" ]; then
-            CMD="$CMD buildSite"
+            TASKS="$TASKS buildSite"
           fi
-          
-          echo "Running: $CMD"
-          
-          echo "IS_BUILT=false" >> $GITHUB_OUTPUT
-          if [ "$CMD" == "./gradlew --no-daemon" ]; then
+
+          TASKS="$(echo "$TASKS" | xargs)"
+
+          if [ -z "$TASKS" ]; then
+            echo "IS_BUILT=false" >> $GITHUB_OUTPUT
             echo "Nothing to build"
             exit 0
           fi
-          
+
           echo "IS_BUILT=true" >> $GITHUB_OUTPUT
-          
-          docker run --rm \
-            -v ${{ github.workspace }}:/app \
-            -v $HOME/.gradle:/root/.gradle \
-            -e SITE_EMAIL \
-            -e SITE_ADDRESS_NAME \
-            -e SITE_STREET \
-            -e SITE_PLZ \
-            -e SITE_CITY \
-            -e SITE_TEL \
-            -e SITE_BASE_URL \
-            -e REQUIRE_SITE_BASE_URL \
-            -w /app \
-            ${{ steps.set_image.outputs.IMAGE_NAME }} \
-            $CMD
+
+          # The build runs through build.sh so CI and local builds share one
+          # container invocation and image tag. Forward the Gradle cache to the
+          # cached host directory.
+          export GRADLE_CACHE="$HOME/.gradle"
+          echo "Running: ./build.sh $TASKS"
+          ./build.sh $TASKS
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
@@ -152,13 +137,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set image
-        id: set_image
-        run: echo "IMAGE_NAME=ghcr.io/docs-as-code-toolkit/docs-toolbox:v1.3.1" >> $GITHUB_OUTPUT
-
-      - name: Pull runtime image
-        run: docker pull ${{ steps.set_image.outputs.IMAGE_NAME }}
-
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -167,20 +145,17 @@ jobs:
 
       - name: Run validation and generator checks
         run: |
-          docker run --rm \
-            -v ${{ github.workspace }}:/app \
-            -v $HOME/.gradle:/root/.gradle \
-            -w /app \
-            ${{ steps.set_image.outputs.IMAGE_NAME }} \
-            ./gradlew --no-daemon \
-              validateProfileMetamodel \
-              generateProfileArtifacts \
-              generateArchitectureArtifacts \
-              generateArticleSummaries \
-              checkAgentAdapters \
-              testAgentAdapters \
-              testProfileNavigation \
-              testSiteMetadata
+          export GRADLE_CACHE="$HOME/.gradle"
+          ./build.sh \
+            validateProfileMetamodel \
+            generateProfileArtifacts \
+            generateArchitectureArtifacts \
+            generateArticleSummaries \
+            checkAgentAdapters \
+            testAgentAdapters \
+            testProfileNavigation \
+            testProfileListings \
+            testSiteMetadata
 
   deploy-site:
     needs: [build-docs, detect-changes]

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,13 @@ done
 # it with a host path (for example $HOME/.gradle) so actions/cache can persist it.
 GRADLE_CACHE="${GRADLE_CACHE:-gradle-cache}"
 
+# A host path (contains a slash) must exist before it can be bind-mounted;
+# Podman errors on a missing source instead of creating it like Docker does.
+# Named volumes (no slash) are managed by the engine and left untouched.
+case "$GRADLE_CACHE" in
+    */*) mkdir -p "$GRADLE_CACHE" ;;
+esac
+
 # Run
 $ENGINE run --rm \
     $ENV_FILE \

--- a/build.sh
+++ b/build.sh
@@ -29,11 +29,32 @@ fi
 ENV_FILE=""
 [ -f .env ] && ENV_FILE="--env-file .env"
 
+# Personal and site build variables the Gradle build reads via env(). They are
+# forwarded into the container only when set on the host, so a present value
+# (for example from CI secrets) reaches the build without an empty -e clobbering
+# a value coming from .env locally.
+PASS_ENV=(
+    SITE_EMAIL SITE_ADDRESS_NAME SITE_STREET SITE_PLZ SITE_CITY SITE_TEL
+    SITE_BASE_URL REQUIRE_SITE_BASE_URL
+    CONTACT_STREET CONTACT_PLZ CONTACT_CITY CONTACT_TEL CONTACT_TEL_PRINT CONTACT_EMAIL
+)
+ENV_ARGS=()
+for var in "${PASS_ENV[@]}"; do
+    if [ -n "${!var+x}" ]; then
+        ENV_ARGS+=(-e "$var")
+    fi
+done
+
+# Gradle cache location. Defaults to a named volume for local reuse; CI overrides
+# it with a host path (for example $HOME/.gradle) so actions/cache can persist it.
+GRADLE_CACHE="${GRADLE_CACHE:-gradle-cache}"
+
 # Run
 $ENGINE run --rm \
     $ENV_FILE \
+    "${ENV_ARGS[@]}" \
     -v "$PWD":/app \
-    -v gradle-cache:/root/.gradle \
+    -v "$GRADLE_CACHE":/root/.gradle \
     -w /app \
     "$IMAGE_NAME" \
     ./gradlew --no-daemon "$@"


### PR DESCRIPTION
Closes #39.

## Zusammenfassung

Gleicht die CI-Pipeline an den dokumentierten lokalen Workflow an: `build-docs` und `pr-check` rufen jetzt `./build.sh <tasks>` statt inline `docker run … ./gradlew`. Der Runtime-Image-Tag ist damit nur noch in `build.sh` definiert (Single Source).

- **`build.sh`**: reicht die site-/contact-relevanten Build-Variablen in den Container durch, sofern gesetzt (`SITE_*`, `SITE_BASE_URL`, `REQUIRE_SITE_BASE_URL`, `CONTACT_*`) — verhindert das Überschreiben von `.env` lokal. Gradle-Cache über `GRADLE_CACHE` überschreibbar (Default: benanntes Volume; CI: `$HOME/.gradle`).
- **`update-profile.yml`**: doppelte `IMAGE_NAME`-Definition und separate Pull-Steps entfernt; `GRADLE_CACHE=$HOME/.gradle` gesetzt, damit `actions/cache` weiter greift; `testProfileListings` in `pr-check` ergänzt (fehlte seit #37).

## Verifikation

Lokaler Container-Lauf über `build.sh` (der `build-docs`-Job läuft per `if:` nicht auf Pull Requests, daher lokal verifiziert):

- `./build.sh validateProfileMetamodel testProfileListings buildSite` → BUILD SUCCESSFUL.
- **Env-Forwarding**: mit `REQUIRE_SITE_BASE_URL=true` + `SITE_BASE_URL` lief die Canonical-Injection durch (sonst Abbruch); Canonical-Links korrekt in den generierten Listen-Seiten.
- **Cache-Override**: Host-Cache-Verzeichnis wurde befüllt.
- `bash -n build.sh` ok, Workflow-YAML valide, keine `docker run`/`IMAGE_NAME`-Reste mehr.

## Hinweis

Kein BDD-`.feature` nötig: reine CI-/Build-Verdrahtung ohne neue fachliche Laufzeit-Behaviour (Änderung an der Ausführungsumgebung, nicht am beobachtbaren Produktverhalten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
