### PR TITLE
Add GitHub-backed article comments

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -155,6 +155,7 @@ jobs:
             testAgentAdapters \
             testProfileNavigation \
             testProfileListings \
+            testProfileComments \
             testSiteMetadata
 
   deploy-site:
@@ -188,6 +189,24 @@ jobs:
           mirror -R --delete --verbose ./build/site ${SFTP_REMOTE_BASE}/site
           bye
           EOF
+
+      - name: Checkout article comments repository
+        uses: actions/checkout@v4
+        with:
+          repository: dieterbaier/profile-artikelkommentare
+          token: ${{ secrets.ARTICLE_COMMENTS_REPO_TOKEN }}
+          path: article-comments-repo
+
+      - name: Synchronize published article IDs
+        run: |
+          mkdir -p article-comments-repo/config
+          cp build/article-comments/allowed-article-ids.json article-comments-repo/config/allowed-article-ids.json
+          cd article-comments-repo
+          git config user.name "github-actions"
+          git config user.email "actions@github.com"
+          git add config/allowed-article-ids.json
+          git commit -m "Update published article IDs" || echo "no changes"
+          git push origin HEAD:main
 
   deploy-architecture:
     needs: [build-docs, detect-changes]

--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -177,19 +177,6 @@ jobs:
           name: docs
           path: build
 
-      - name: Install lftp
-        run: sudo apt-get update && sudo apt-get install -y lftp
-
-      - name: Deploy site to private webspace
-        run: |
-          lftp -u "$SFTP_USER","$SFTP_PASSWORD" sftp://$SFTP_HOST:$SFTP_PORT <<EOF
-          set sftp:auto-confirm yes
-          set net:max-retries 2
-          set net:timeout 20
-          mirror -R --delete --verbose ./build/site ${SFTP_REMOTE_BASE}/site
-          bye
-          EOF
-
       - name: Checkout article comments repository
         uses: actions/checkout@v4
         with:
@@ -207,6 +194,19 @@ jobs:
           git add config/allowed-article-ids.json
           git commit -m "Update published article IDs" || echo "no changes"
           git push origin HEAD:main
+
+      - name: Install lftp
+        run: sudo apt-get update && sudo apt-get install -y lftp
+
+      - name: Deploy site to private webspace
+        run: |
+          lftp -u "$SFTP_USER","$SFTP_PASSWORD" sftp://$SFTP_HOST:$SFTP_PORT <<EOF
+          set sftp:auto-confirm yes
+          set net:max-retries 2
+          set net:timeout 20
+          mirror -R --delete --verbose ./build/site ${SFTP_REMOTE_BASE}/site
+          bye
+          EOF
 
   deploy-architecture:
     needs: [build-docs, detect-changes]

--- a/build.gradle
+++ b/build.gradle
@@ -445,6 +445,9 @@ tasks.register('testProfileComments') {
         exec {
             commandLine 'ruby', '-Itest', 'test/profile_comments_test.rb'
         }
+        exec {
+            commandLine 'node', '--test', 'test/article_comments_test.mjs'
+        }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -434,6 +434,20 @@ tasks.register('testProfileListings') {
     }
 }
 
+tasks.register('testProfileComments') {
+    description = 'Runs the GitHub-backed article comments behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_comments_test.rb')
+    inputs.files('features/article-comments.feature', 'src-content/theme/article-comments.js', 'src-content/theme/style.css')
+    inputs.files('templates/write-article/article.adoc')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_comments_test.rb'
+        }
+    }
+}
+
 // Readme
 asciidoctorBase('buildReadmeDocbook','','src-content/profile/readme', 'build/readme/docbook', [],true, 'docbook')
 tasks.register('convertDocBookToMarkdown', PandocTask) {

--- a/build.gradle
+++ b/build.gradle
@@ -327,6 +327,7 @@ tasks.register('generateProfileArtifacts') {
     })
     inputs.files('metamodel/profile-artifact.schema.yaml', 'metamodel/relations.schema.yaml', 'scripts/validate-profile-metamodel.rb')
     outputs.dir('src-content/profile/generated')
+    outputs.file('build/article-comments/allowed-article-ids.json')
 
     doLast {
         exec {

--- a/features/article-comments.feature
+++ b/features/article-comments.feature
@@ -22,3 +22,8 @@ Feature: GitHub-backed article comments
     Given a generated article comment include
     When the article is rendered for a non-website target
     Then the website-only comment block is omitted
+
+  Scenario: Only published article ids are synchronized
+    Given published, preview, and non-website articles
+    When the deployment allowlist is generated
+    Then it contains only article ids eligible for the public website

--- a/features/article-comments.feature
+++ b/features/article-comments.feature
@@ -11,12 +11,12 @@ Feature: GitHub-backed article comments
   Scenario: Each article receives a prefilled comment link
     Given a metadata-backed article
     When profile artifacts are generated
-    Then its comment block links to a new GitHub issue marked with the article id and title
+    Then its comment block opens the dedicated GitHub issue form with article id, title, and current page URL
 
   Scenario: Existing comments can be requested explicitly
     Given an article comment block on the static website
     When the reader requests existing comments
-    Then the local enhancement loads matching GitHub issues and presents their headings as links
+    Then the local enhancement loads issues carrying the comment and article id labels and presents their headings as links
 
   Scenario: Non-website article exports omit the comment block
     Given a generated article comment include

--- a/features/article-comments.feature
+++ b/features/article-comments.feature
@@ -1,0 +1,24 @@
+# Living documentation for https://github.com/dieterbaier/profile/issues/44[feature #44]: GitHub-backed article comments.
+#
+# Bridged to: test/profile_comments_test.rb (classic Minitest). Each scenario maps
+# to a test method named after its sanitized title with Given/When/Then anchors.
+
+Feature: GitHub-backed article comments
+  As a reader of a profile article
+  I want to comment through a prefilled GitHub issue
+  So that I can give public, article-specific feedback without a website backend
+
+  Scenario: Each article receives a prefilled comment link
+    Given a metadata-backed article
+    When profile artifacts are generated
+    Then its comment block links to a new GitHub issue marked with the article id and title
+
+  Scenario: Existing comments can be requested explicitly
+    Given an article comment block on the static website
+    When the reader requests existing comments
+    Then the local enhancement loads matching GitHub issues and presents their headings as links
+
+  Scenario: Non-website article exports omit the comment block
+    Given a generated article comment include
+    When the article is rendered for a non-website target
+    Then the website-only comment block is omitted

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -27,6 +27,7 @@ class ProfileArtifactValidator
   RECENT_LIMIT = 10
   # Default display language for article listings when none is requested.
   DEFAULT_LANGUAGE = 'de'
+  ARTICLE_COMMENTS_REPOSITORY = 'dieterbaier/profile'
   LANGUAGES = %w[de en mixed].freeze
   CHANNELS = %w[website cv readme github gitlab markdown-export pdf].freeze
   RELATION_TYPES = %w[addresses depends_on constrains refines supersedes conflicts_with mitigates introduces_risk affects verifies documents relates_to].freeze
@@ -101,6 +102,23 @@ class ProfileArtifactValidator
     end
   end
 
+  # Writes the progressive-enhancement block used to create and display GitHub
+  # issues for an article. The optional issue list is loaded by a local script
+  # only after the reader explicitly requests it.
+  def generate_article_comment_includes(artifacts)
+    articles = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
+
+    clean_generated_comment_includes
+
+    articles.map do |article|
+      comments_dir = article_source_path(article).dirname.join('generated')
+      FileUtils.mkdir_p(comments_dir)
+      comments_path = comments_dir.join("#{article_slug(article)}-comments.adoc")
+      comments_path.write(render_article_comments(article), encoding: 'UTF-8')
+      comments_path
+    end
+  end
+
   # Generates the article listings from metadata: a "recent" include fragment
   # (RECENT_LIMIT newest public articles) plus standalone overview pages for all
   # articles, each tag, and each skill. Fragments live under
@@ -169,6 +187,12 @@ class ProfileArtifactValidator
 
   def clean_generated_tag_includes
     Dir.glob(profile_dir.join('**', 'generated', '*-tags.adoc').to_s).each do |path|
+      File.delete(path)
+    end
+  end
+
+  def clean_generated_comment_includes
+    Dir.glob(profile_dir.join('**', 'generated', '*-comments.adoc').to_s).each do |path|
       File.delete(path)
     end
   end
@@ -599,6 +623,33 @@ class ProfileArtifactValidator
      ''].join("\n")
   end
 
+  def render_article_comments(article)
+    article_id = article.metadata['id'].to_s
+    article_title = article.metadata['title'].to_s
+    marker = "[Artikelkommentar][#{article_id}]"
+    issue_title = "#{marker} #{article_title}"
+    issue_body = "Kommentar zum Artikel: #{article_title}\n\nArtikel-ID: #{article_id}\n\nMein Kommentar:\n"
+    new_issue_url = "https://github.com/#{ARTICLE_COMMENTS_REPOSITORY}/issues/new?" \
+                    "title=#{CGI.escape(issue_title)}&body=#{CGI.escape(issue_body)}"
+
+    ['// Generated article comments. Do not edit manually.',
+     'ifdef::buildsite[]',
+     '[subs="attributes"]',
+     '++++',
+     "<section class=\"article-comments\" data-article-comments data-repository=\"#{h(ARTICLE_COMMENTS_REPOSITORY)}\" data-issue-marker=\"#{h(marker)}\">",
+     '  <h2>Kommentare</h2>',
+     '  <p>Fragen, Ergänzungen oder Feedback sind willkommen und werden als öffentliches GitHub-Issue erfasst.</p>',
+     "  <p><a class=\"article-comment-create fingerPointsTo\" href=\"#{h(new_issue_url)}\" target=\"_blank\" rel=\"noopener noreferrer\">Diesen Artikel kommentieren</a></p>",
+     '  <button class="article-comments-load" type="button">Vorhandene Kommentare laden</button>',
+     '  <p class="article-comments-status" aria-live="polite"></p>',
+     '  <ul class="article-comments-list"></ul>',
+     '</section>',
+     '<script src="{basedir}/stylesheet/article-comments.js"></script>',
+     '++++',
+     'endif::[]',
+     ''].join("\n")
+  end
+
   def tag_links_html(tags, from_dir:, articles_dir:)
     tags.map do |tag|
       href = h(article_href(from_dir, tag_page_output_path(articles_dir, tag)))
@@ -833,6 +884,8 @@ if $PROGRAM_NAME == __FILE__
     puts "Generated #{nav_paths.length} article navigation include(s)."
     tag_paths = validator.generate_article_tag_includes(artifacts)
     puts "Generated #{tag_paths.length} article tag include(s)."
+    comment_paths = validator.generate_article_comment_includes(artifacts)
+    puts "Generated #{comment_paths.length} article comment include(s)."
     list_paths = validator.generate_article_lists(artifacts)
     puts "Generated #{list_paths.length} article list file(s)."
   end

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -27,7 +27,8 @@ class ProfileArtifactValidator
   RECENT_LIMIT = 10
   # Default display language for article listings when none is requested.
   DEFAULT_LANGUAGE = 'de'
-  ARTICLE_COMMENTS_REPOSITORY = 'dieterbaier/profile'
+  ARTICLE_COMMENTS_REPOSITORY = 'dieterbaier/profile-artikelkommentare'
+  ARTICLE_COMMENTS_TEMPLATE = 'artikelkommentar.yml'
   LANGUAGES = %w[de en mixed].freeze
   CHANNELS = %w[website cv readme github gitlab markdown-export pdf].freeze
   RELATION_TYPES = %w[addresses depends_on constrains refines supersedes conflicts_with mitigates introduces_risk affects verifies documents relates_to].freeze
@@ -626,17 +627,16 @@ class ProfileArtifactValidator
   def render_article_comments(article)
     article_id = article.metadata['id'].to_s
     article_title = article.metadata['title'].to_s
-    marker = "[Artikelkommentar][#{article_id}]"
-    issue_title = "#{marker} #{article_title}"
-    issue_body = "Kommentar zum Artikel: #{article_title}\n\nArtikel-ID: #{article_id}\n\nMein Kommentar:\n"
+    issue_title = "[Artikelkommentar] [#{article_id}] #{article_title}"
     new_issue_url = "https://github.com/#{ARTICLE_COMMENTS_REPOSITORY}/issues/new?" \
-                    "title=#{CGI.escape(issue_title)}&body=#{CGI.escape(issue_body)}"
+                    "template=#{CGI.escape(ARTICLE_COMMENTS_TEMPLATE)}&title=#{CGI.escape(issue_title)}&" \
+                    "article_id=#{CGI.escape(article_id)}&article_title=#{CGI.escape(article_title)}"
 
     ['// Generated article comments. Do not edit manually.',
      'ifdef::buildsite[]',
      '[subs="attributes"]',
      '++++',
-     "<section class=\"article-comments\" data-article-comments data-repository=\"#{h(ARTICLE_COMMENTS_REPOSITORY)}\" data-issue-marker=\"#{h(marker)}\">",
+     "<section class=\"article-comments\" data-article-comments data-repository=\"#{h(ARTICLE_COMMENTS_REPOSITORY)}\" data-article-id=\"#{h(article_id)}\">",
      '  <h2>Kommentare</h2>',
      '  <p>Fragen, Ergänzungen oder Feedback sind willkommen und werden als öffentliches GitHub-Issue erfasst.</p>',
      "  <p><a class=\"article-comment-create fingerPointsTo\" href=\"#{h(new_issue_url)}\" target=\"_blank\" rel=\"noopener noreferrer\">Diesen Artikel kommentieren</a></p>",

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -4,6 +4,7 @@
 require 'cgi'
 require 'date'
 require 'fileutils'
+require 'json'
 require 'optparse'
 require 'pathname'
 require 'set'
@@ -118,6 +119,22 @@ class ProfileArtifactValidator
       comments_path.write(render_article_comments(article), encoding: 'UTF-8')
       comments_path
     end
+  end
+
+  # Writes the stable IDs of articles eligible for the public website. The
+  # deployment workflow synchronizes this allowlist to the comments repository,
+  # where its issue workflow uses it for semantic article-ID validation.
+  def generate_article_comment_allowlist(artifacts, output:)
+    article_ids = artifacts.select do |artifact|
+      metadata = artifact.metadata
+      metadata['type'] == 'Article' && metadata['status'] == 'published' &&
+        Array(metadata['channels']).include?('website')
+    end.map { |article| article.metadata['id'] }.sort
+
+    output_path = root.join(output)
+    FileUtils.mkdir_p(output_path.dirname)
+    output_path.write(JSON.pretty_generate({ 'schema_version' => 1, 'article_ids' => article_ids }) + "\n", encoding: 'UTF-8')
+    output_path
   end
 
   # Generates the article listings from metadata: a "recent" include fragment
@@ -860,13 +877,15 @@ if $PROGRAM_NAME == __FILE__
     root: default_root,
     profile_dir: nil,
     generate: false,
-    output: nil
+    output: nil,
+    article_comment_allowlist: nil
   }
   OptionParser.new do |parser|
     parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
     parser.on('--profile-dir PATH') { |value| options[:profile_dir] = Pathname.new(value) }
     parser.on('--generate') { options[:generate] = true }
     parser.on('--output PATH') { |value| options[:output] = value }
+    parser.on('--article-comment-allowlist PATH') { |value| options[:article_comment_allowlist] = value }
   end.parse!
 
   root = options[:root]
@@ -886,6 +905,11 @@ if $PROGRAM_NAME == __FILE__
     puts "Generated #{tag_paths.length} article tag include(s)."
     comment_paths = validator.generate_article_comment_includes(artifacts)
     puts "Generated #{comment_paths.length} article comment include(s)."
+    allowlist_path = validator.generate_article_comment_allowlist(
+      artifacts,
+      output: options[:article_comment_allowlist] || 'build/article-comments/allowed-article-ids.json'
+    )
+    puts "Generated article comment allowlist: #{allowlist_path.relative_path_from(root)}"
     list_paths = validator.generate_article_lists(artifacts)
     puts "Generated #{list_paths.length} article list file(s)."
   end

--- a/src-content/docs/arc42/09-architecture-decisions/adr-005-minimal-static-site.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-005-minimal-static-site.adoc
@@ -29,6 +29,12 @@ Proposed (derived).
 === Decision
 
 Keep the public website static and avoid unnecessary third-party runtime behavior.
+Optional integrations may use progressive enhancement when the core content and
+navigation work without them and the reader explicitly triggers any third-party
+request. The article-comments proof of concept follows this boundary: creating a
+comment navigates to GitHub, while loading existing comment issues requires an
+explicit button click. This applies ADR-005 to
+https://github.com/dieterbaier/profile/issues/44[feature #44].
 
 === Context
 
@@ -48,5 +54,9 @@ s| Sum s| +3 s| ? s| -3
 === Consequences
 
 * Positive: The project keeps a coherent source-based publishing workflow.
+* Positive: Reading an article does not automatically disclose the visit to the
+  optional GitHub comments integration.
 * Negative: Contributors need to understand the chosen toolchain.
+* Negative: The optional comment list depends on GitHub availability and its
+  unauthenticated API rate limit.
 * Follow-up: Human review should confirm the derived status and rationale.

--- a/src-content/docs/arc42/09-architecture-decisions/adr-005-minimal-static-site.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-005-minimal-static-site.adoc
@@ -32,8 +32,9 @@ Keep the public website static and avoid unnecessary third-party runtime behavio
 Optional integrations may use progressive enhancement when the core content and
 navigation work without them and the reader explicitly triggers any third-party
 request. The article-comments proof of concept follows this boundary: creating a
-comment navigates to GitHub, while loading existing comment issues requires an
-explicit button click. This applies ADR-005 to
+comment navigates to a structured issue form in the dedicated
+`dieterbaier/profile-artikelkommentare` repository, while loading label-matched
+comment issues requires an explicit button click. This applies ADR-005 to
 https://github.com/dieterbaier/profile/issues/44[feature #44].
 
 === Context

--- a/src-content/docs/arc42/doc-05000-building-block-view.adoc
+++ b/src-content/docs/arc42/doc-05000-building-block-view.adoc
@@ -81,6 +81,7 @@ package "Publication Targets" {
 }
 
 PublicRepo --> Gradle
+PublicRepo --> CommentsRepo : public deployment synchronizes\narticle-ID allowlist
 PrivateRepo ..> Gradle : proposed private content root
 Architecture --> Gradle
 Theme --> Gradle
@@ -102,7 +103,7 @@ PublicSite --> CommentsRepo : create or explicitly load\nlabelled article commen
 |===
 | Container | Responsibility | Storage
 | Public Profile Repository | Public profile source, public articles, previewable article source, reusable build logic, theme, profile metadata contracts, and architecture documentation. | `dieterbaier/profile`
-| Article Comments Repository | Public GitHub issues created through a structured form. A repository workflow validates the submitted article ID and assigns a stable per-article label. | `dieterbaier/profile-artikelkommentare`
+| Article Comments Repository | Public GitHub issues created through a structured form. A repository workflow validates the submitted article ID against the deployed public-article allowlist and assigns a stable per-article label. | `dieterbaier/profile-artikelkommentare`
 | Private Profile Repository | Private article, note, and protocol source. Proposed as a separate source component, not as a duplicated product. | `dieterbaier/profile-private`
 | Architecture Knowledge | arc42 chapters, ADRs, quality scenarios, risks, canvases, Q&A, and metadata. | `src-content/docs`
 | Theme Assets | CSS, fonts, icons, JavaScript, and shared docinfo fragments used by generated static outputs. For https://github.com/dieterbaier/profile/issues/44[feature #44], the local article-comments script progressively loads matching GitHub issues only after reader consent. | `src-content/theme`, `src-content/profile/includes`

--- a/src-content/docs/arc42/doc-05000-building-block-view.adoc
+++ b/src-content/docs/arc42/doc-05000-building-block-view.adoc
@@ -100,6 +100,7 @@ Gradle --> ArchitectureSite
 |===
 | Container | Responsibility | Storage
 | Public Profile Repository | Public profile source, public articles, previewable article source, reusable build logic, theme, profile metadata contracts, and architecture documentation. | `dieterbaier/profile`
+| Article Comments Repository | Public GitHub issues created through a structured form. A repository workflow validates the submitted article ID and assigns a stable per-article label. | `dieterbaier/profile-artikelkommentare`
 | Private Profile Repository | Private article, note, and protocol source. Proposed as a separate source component, not as a duplicated product. | `dieterbaier/profile-private`
 | Architecture Knowledge | arc42 chapters, ADRs, quality scenarios, risks, canvases, Q&A, and metadata. | `src-content/docs`
 | Theme Assets | CSS, fonts, icons, JavaScript, and shared docinfo fragments used by generated static outputs. For https://github.com/dieterbaier/profile/issues/44[feature #44], the local article-comments script progressively loads matching GitHub issues only after reader consent. | `src-content/theme`, `src-content/profile/includes`

--- a/src-content/docs/arc42/doc-05000-building-block-view.adoc
+++ b/src-content/docs/arc42/doc-05000-building-block-view.adoc
@@ -102,9 +102,9 @@ Gradle --> ArchitectureSite
 | Public Profile Repository | Public profile source, public articles, previewable article source, reusable build logic, theme, profile metadata contracts, and architecture documentation. | `dieterbaier/profile`
 | Private Profile Repository | Private article, note, and protocol source. Proposed as a separate source component, not as a duplicated product. | `dieterbaier/profile-private`
 | Architecture Knowledge | arc42 chapters, ADRs, quality scenarios, risks, canvases, Q&A, and metadata. | `src-content/docs`
-| Theme Assets | CSS, fonts, icons, JavaScript, and shared docinfo fragments used by generated static outputs. | `src-content/theme`, `src-content/profile/includes`
+| Theme Assets | CSS, fonts, icons, JavaScript, and shared docinfo fragments used by generated static outputs. For https://github.com/dieterbaier/profile/issues/44[feature #44], the local article-comments script progressively loads matching GitHub issues only after reader consent. | `src-content/theme`, `src-content/profile/includes`
 | Validators | Check architecture and profile metadata before generation and deployment. | `scripts/`
-| Generators | Create derived indexes, traceability fragments, article summaries, and proposed publication target inputs. | `scripts/` and generated folders
+| Generators | Create derived indexes, traceability fragments, article summaries, article-specific GitHub comment blocks for https://github.com/dieterbaier/profile/issues/44[feature #44], and proposed publication target inputs. | `scripts/` and generated folders
 | Gradle Tasks | Orchestrate build, validation, generation, conversion, and asset copying. | `build.gradle`
 |===
 

--- a/src-content/docs/arc42/doc-05000-building-block-view.adoc
+++ b/src-content/docs/arc42/doc-05000-building-block-view.adoc
@@ -57,6 +57,7 @@ skinparam componentStyle rectangle
 
 package "Source Containers" {
   [Public Profile Repository] as PublicRepo
+  [Article Comments Repository] as CommentsRepo
   [Private Profile Repository] as PrivateRepo
   [Architecture Knowledge] as Architecture
   [Theme Assets] as Theme
@@ -93,6 +94,7 @@ Gradle --> CV
 Gradle --> Readme
 Gradle --> ArticleMarkdown
 Gradle --> ArchitectureSite
+PublicSite --> CommentsRepo : create or explicitly load\nlabelled article comments
 @enduml
 ----
 

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -40,8 +40,10 @@ Failed validation or missing tooling stops the build. Missing publication URLs i
 The GitHub-backed article-comments https://github.com/dieterbaier/profile/issues/44[feature #44]
 keeps the website static.
 Article metadata generates a prefilled issue-form link into the dedicated
-`dieterbaier/profile-artikelkommentare` repository. Its workflow assigns the
-fixed `Artikelkommentar` label and a validated article-ID label. A local,
+`dieterbaier/profile-artikelkommentare` repository. Public-site deployment
+synchronizes an allowlist derived from published website articles. The comments
+workflow idempotently creates and assigns the fixed `Artikelkommentar` label,
+validates the submitted ID against that allowlist, and assigns the article-ID label. A local,
 framework-free script lists issues matching both labels, but contacts the GitHub
 API only after the reader explicitly requests the list. Failure or rate limiting
 affects only the optional list, never the article content. The observable behaviour is specified in

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -35,6 +35,18 @@ CI logs, Gradle task output, and validator reports are the operational feedback 
 
 Failed validation or missing tooling stops the build. Missing publication URLs in AI-generated article summaries are represented as placeholders rather than invented values.
 
+== Optional Article Interaction
+
+The GitHub-backed article-comments https://github.com/dieterbaier/profile/issues/44[feature #44]
+keeps the website static.
+Article metadata generates a prefilled GitHub issue link containing a stable
+article marker. A local, framework-free script can list matching issues by title
+and link, but contacts the GitHub API only after the reader explicitly requests
+the list. Failure or rate limiting affects only the optional list, never the
+article content. The observable behaviour is specified in
+`features/article-comments.feature` and bridged to
+`test/profile_comments_test.rb`.
+
 == Sustainability
 
 Generated output is static. The public site avoids runtime backends, trackers, and unnecessary third-party scripts.

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -39,11 +39,12 @@ Failed validation or missing tooling stops the build. Missing publication URLs i
 
 The GitHub-backed article-comments https://github.com/dieterbaier/profile/issues/44[feature #44]
 keeps the website static.
-Article metadata generates a prefilled GitHub issue link containing a stable
-article marker. A local, framework-free script can list matching issues by title
-and link, but contacts the GitHub API only after the reader explicitly requests
-the list. Failure or rate limiting affects only the optional list, never the
-article content. The observable behaviour is specified in
+Article metadata generates a prefilled issue-form link into the dedicated
+`dieterbaier/profile-artikelkommentare` repository. Its workflow assigns the
+fixed `Artikelkommentar` label and a validated article-ID label. A local,
+framework-free script lists issues matching both labels, but contacts the GitHub
+API only after the reader explicitly requests the list. Failure or rate limiting
+affects only the optional list, never the article content. The observable behaviour is specified in
 `features/article-comments.feature` and bridged to
 `test/profile_comments_test.rb`.
 

--- a/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
+++ b/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
@@ -230,4 +230,5 @@ Die Grundlage dafür ist bereits gelegt.
 // Generated article navigation (previous/next and related articles); website only.
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-comments.adoc[opts=optional]
 endif::[]

--- a/src-content/profile/site/articles/architecture/sustainability.adoc
+++ b/src-content/profile/site/articles/architecture/sustainability.adoc
@@ -130,4 +130,5 @@ Sie ist das Ergebnis vieler kleiner Entscheidungen.
 // Generated article navigation (previous/next and related articles); website only.
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-comments.adoc[opts=optional]
 endif::[]

--- a/src-content/profile/site/articles/documentation/doc-as-code.adoc
+++ b/src-content/profile/site/articles/documentation/doc-as-code.adoc
@@ -255,4 +255,5 @@ endif::[]
 // Generated article navigation (previous/next and related articles); website only.
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-comments.adoc[opts=optional]
 endif::[]

--- a/src-content/theme/article-comments.js
+++ b/src-content/theme/article-comments.js
@@ -1,6 +1,15 @@
 (function () {
     "use strict";
 
+    function prepareCreateLink(container) {
+        const link = container.querySelector(".article-comment-create");
+        if (!link) return;
+
+        const url = new URL(link.href);
+        url.searchParams.set("article_url", window.location.href);
+        link.href = url.toString();
+    }
+
     function renderIssues(container, issues) {
         const list = container.querySelector(".article-comments-list");
         const status = container.querySelector(".article-comments-status");
@@ -26,11 +35,11 @@
 
     async function loadIssues(container, button) {
         const repository = container.dataset.repository;
-        const marker = container.dataset.issueMarker;
+        const articleId = container.dataset.articleId;
         const status = container.querySelector(".article-comments-status");
         const perPage = 100;
         const searchLimit = 1000;
-        const query = "repo:" + repository + " in:title \"" + marker + "\"";
+        const query = "repo:" + repository + " is:issue label:\"Artikelkommentar\" label:\"" + articleId + "\"";
         const endpoint = "https://api.github.com/search/issues?q=" + encodeURIComponent(query) +
             "&sort=created&order=desc&per_page=" + perPage;
 
@@ -57,7 +66,10 @@
             } while (issues.length < resultCount);
 
             const matchingIssues = issues.filter(function (issue) {
-                return !issue.pull_request && issue.title.indexOf(marker) !== -1;
+                const labels = issue.labels.map(function (label) {
+                    return typeof label === "string" ? label : label.name;
+                });
+                return !issue.pull_request && labels.indexOf("Artikelkommentar") !== -1 && labels.indexOf(articleId) !== -1;
             });
             renderIssues(container, matchingIssues);
             button.hidden = true;
@@ -68,6 +80,7 @@
     }
 
     document.querySelectorAll("[data-article-comments]").forEach(function (container) {
+        prepareCreateLink(container);
         const button = container.querySelector(".article-comments-load");
         if (button) button.addEventListener("click", function () { return loadIssues(container, button); });
     });

--- a/src-content/theme/article-comments.js
+++ b/src-content/theme/article-comments.js
@@ -1,0 +1,54 @@
+(function () {
+    "use strict";
+
+    function renderIssues(container, issues) {
+        const list = container.querySelector(".article-comments-list");
+        const status = container.querySelector(".article-comments-status");
+        list.replaceChildren();
+
+        if (issues.length === 0) {
+            status.textContent = "Noch keine Kommentare vorhanden.";
+            return;
+        }
+
+        issues.forEach(function (issue) {
+            const item = document.createElement("li");
+            const link = document.createElement("a");
+            link.href = issue.html_url;
+            link.textContent = issue.title;
+            link.target = "_blank";
+            link.rel = "noopener noreferrer";
+            item.appendChild(link);
+            list.appendChild(item);
+        });
+        status.textContent = issues.length === 1 ? "Ein Kommentar:" : issues.length + " Kommentare:";
+    }
+
+    async function loadIssues(container, button) {
+        const repository = container.dataset.repository;
+        const marker = container.dataset.issueMarker;
+        const status = container.querySelector(".article-comments-status");
+        const endpoint = "https://api.github.com/repos/" + repository + "/issues?state=all&per_page=100&sort=created&direction=desc";
+
+        button.disabled = true;
+        status.textContent = "Kommentare werden von GitHub geladen …";
+
+        try {
+            const response = await fetch(endpoint, { headers: { Accept: "application/vnd.github+json" } });
+            if (!response.ok) throw new Error("GitHub API returned " + response.status);
+            const issues = (await response.json()).filter(function (issue) {
+                return !issue.pull_request && issue.title.indexOf(marker) !== -1;
+            });
+            renderIssues(container, issues);
+            button.hidden = true;
+        } catch (error) {
+            status.textContent = "Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.";
+            button.disabled = false;
+        }
+    }
+
+    document.querySelectorAll("[data-article-comments]").forEach(function (container) {
+        const button = container.querySelector(".article-comments-load");
+        if (button) button.addEventListener("click", function () { loadIssues(container, button); });
+    });
+})();

--- a/src-content/theme/article-comments.js
+++ b/src-content/theme/article-comments.js
@@ -28,18 +28,38 @@
         const repository = container.dataset.repository;
         const marker = container.dataset.issueMarker;
         const status = container.querySelector(".article-comments-status");
-        const endpoint = "https://api.github.com/repos/" + repository + "/issues?state=all&per_page=100&sort=created&direction=desc";
+        const perPage = 100;
+        const searchLimit = 1000;
+        const query = "repo:" + repository + " in:title \"" + marker + "\"";
+        const endpoint = "https://api.github.com/search/issues?q=" + encodeURIComponent(query) +
+            "&sort=created&order=desc&per_page=" + perPage;
 
         button.disabled = true;
         status.textContent = "Kommentare werden von GitHub geladen …";
 
         try {
-            const response = await fetch(endpoint, { headers: { Accept: "application/vnd.github+json" } });
-            if (!response.ok) throw new Error("GitHub API returned " + response.status);
-            const issues = (await response.json()).filter(function (issue) {
+            const issues = [];
+            let page = 1;
+            let resultCount = 0;
+
+            do {
+                const response = await fetch(endpoint + "&page=" + page, {
+                    headers: { Accept: "application/vnd.github+json" }
+                });
+                if (!response.ok) throw new Error("GitHub API returned " + response.status);
+
+                const result = await response.json();
+                if (result.incomplete_results) throw new Error("GitHub search returned incomplete results");
+                if (result.total_count > searchLimit) throw new Error("GitHub search result limit exceeded");
+                resultCount = Math.min(result.total_count, searchLimit);
+                issues.push.apply(issues, result.items);
+                page += 1;
+            } while (issues.length < resultCount);
+
+            const matchingIssues = issues.filter(function (issue) {
                 return !issue.pull_request && issue.title.indexOf(marker) !== -1;
             });
-            renderIssues(container, issues);
+            renderIssues(container, matchingIssues);
             button.hidden = true;
         } catch (error) {
             status.textContent = "Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.";
@@ -49,6 +69,6 @@
 
     document.querySelectorAll("[data-article-comments]").forEach(function (container) {
         const button = container.querySelector(".article-comments-load");
-        if (button) button.addEventListener("click", function () { loadIssues(container, button); });
+        if (button) button.addEventListener("click", function () { return loadIssues(container, button); });
     });
 })();

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -124,6 +124,40 @@ footer {
     margin-right: auto;
 }
 
+/* Optional, reader-triggered GitHub discussion for articles. */
+.article-comments {
+    margin-top: 3rem;
+    padding: 1.25rem;
+    background: #f6f8fa;
+}
+
+.article-comments h2 {
+    margin-top: 0;
+}
+
+.article-comments-load {
+    padding: 0.55rem 0.85rem;
+    border: 1px solid currentColor;
+    border-radius: 0.3rem;
+    color: inherit;
+    background: transparent;
+    cursor: pointer;
+}
+
+.article-comments-load:disabled {
+    cursor: wait;
+    opacity: 0.65;
+}
+
+.article-comments-status:empty,
+.article-comments-list:empty {
+    display: none;
+}
+
+.article-comments-list li + li {
+    margin-top: 0.5rem;
+}
+
 body {
     font-family: "Noto Sans", sans-serif;
     color: var(--text-color);

--- a/templates/write-article/article.adoc
+++ b/templates/write-article/article.adoc
@@ -84,4 +84,5 @@ toc::[]
 // skipped in the readme/markdown export.
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-comments.adoc[opts=optional]
 endif::[]

--- a/test/article_comments_test.mjs
+++ b/test/article_comments_test.mjs
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+import vm from 'node:vm';
+
+const script = await readFile(new URL('../src-content/theme/article-comments.js', import.meta.url), 'utf8');
+
+class Element {
+    constructor(kind = 'div') {
+        this.kind = kind;
+        this.children = [];
+        this.dataset = {};
+        this.disabled = false;
+        this.hidden = false;
+        this.textContent = '';
+    }
+
+    addEventListener(_event, listener) {
+        this.listener = listener;
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+    }
+
+    replaceChildren() {
+        this.children = [];
+    }
+}
+
+function articleComments(fetch) {
+    const button = new Element('button');
+    const status = new Element('p');
+    const list = new Element('ul');
+    const elements = {
+        '.article-comments-load': button,
+        '.article-comments-status': status,
+        '.article-comments-list': list
+    };
+    const container = new Element('section');
+    container.dataset = {
+        repository: 'dieterbaier/profile',
+        issueMarker: '[Artikelkommentar][ART-101-example]'
+    };
+    container.querySelector = selector => elements[selector];
+
+    const document = {
+        createElement: kind => new Element(kind),
+        querySelectorAll: () => [container]
+    };
+    vm.runInNewContext(script, { document, fetch });
+
+    return { button, list, status };
+}
+
+test('existing comments use server-side search pagination and render matching issues', async () => {
+    // Given: two result pages containing exact matches and a defensive mismatch
+    const requests = [];
+    const pages = [
+        {
+            total_count: 101,
+            incomplete_results: false,
+            items: Array.from({ length: 100 }, (_, index) => ({
+                title: `[Artikelkommentar][ART-101-example] Kommentar ${index + 1}`,
+                html_url: `https://github.com/dieterbaier/profile/issues/${index + 1}`
+            }))
+        },
+        {
+            total_count: 101,
+            incomplete_results: false,
+            items: [
+                {
+                    title: '[Artikelkommentar][ART-101-example] Kommentar 101',
+                    html_url: 'https://github.com/dieterbaier/profile/issues/101'
+                },
+                {
+                    title: '[Artikelkommentar][ART-OTHER] Kein Treffer',
+                    html_url: 'https://github.com/dieterbaier/profile/issues/102'
+                }
+            ]
+        }
+    ];
+    const fetch = async url => {
+        requests.push(url);
+        return { ok: true, json: async () => pages[requests.length - 1] };
+    };
+    const { button, list, status } = articleComments(fetch);
+
+    // When: the reader explicitly loads existing comments
+    await button.listener();
+
+    // Then: GitHub narrows by repository and title marker, all pages are read,
+    // and only exact marker matches are rendered safely as links
+    assert.equal(requests.length, 2);
+    assert.match(requests[0], /^https:\/\/api\.github\.com\/search\/issues\?/);
+    assert.match(decodeURIComponent(requests[0]), /repo:dieterbaier\/profile in:title "\[Artikelkommentar\]\[ART-101-example\]"/);
+    assert.match(requests[0], /page=1$/);
+    assert.match(requests[1], /page=2$/);
+    assert.equal(list.children.length, 101);
+    assert.equal(list.children[100].children[0].textContent, '[Artikelkommentar][ART-101-example] Kommentar 101');
+    assert.equal(status.textContent, '101 Kommentare:');
+    assert.equal(button.hidden, true);
+});
+
+test('searches beyond the GitHub result limit remain retryable', async () => {
+    // Given: more comments exist than GitHub Search can return
+    const fetch = async () => ({
+        ok: true,
+        json: async () => ({ total_count: 1001, incomplete_results: false, items: [] })
+    });
+    const { button, status } = articleComments(fetch);
+
+    // When: the reader loads comments
+    await button.listener();
+
+    // Then: the optional interaction reports failure without disabling retry
+    assert.equal(status.textContent, 'Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.');
+    assert.equal(button.disabled, false);
+    assert.equal(button.hidden, false);
+});

--- a/test/article_comments_test.mjs
+++ b/test/article_comments_test.mjs
@@ -32,15 +32,18 @@ function articleComments(fetch) {
     const button = new Element('button');
     const status = new Element('p');
     const list = new Element('ul');
+    const createLink = new Element('a');
+    createLink.href = 'https://github.com/dieterbaier/profile-artikelkommentare/issues/new?template=artikelkommentar.yml';
     const elements = {
+        '.article-comment-create': createLink,
         '.article-comments-load': button,
         '.article-comments-status': status,
         '.article-comments-list': list
     };
     const container = new Element('section');
     container.dataset = {
-        repository: 'dieterbaier/profile',
-        issueMarker: '[Artikelkommentar][ART-101-example]'
+        repository: 'dieterbaier/profile-artikelkommentare',
+        articleId: 'ART-101-example'
     };
     container.querySelector = selector => elements[selector];
 
@@ -48,9 +51,10 @@ function articleComments(fetch) {
         createElement: kind => new Element(kind),
         querySelectorAll: () => [container]
     };
-    vm.runInNewContext(script, { document, fetch });
+    const window = { location: { href: 'http://localhost:63342/articles/example.html' } };
+    vm.runInNewContext(script, { document, fetch, URL, window });
 
-    return { button, list, status };
+    return { button, createLink, list, status };
 }
 
 test('existing comments use server-side search pagination and render matching issues', async () => {
@@ -61,8 +65,9 @@ test('existing comments use server-side search pagination and render matching is
             total_count: 101,
             incomplete_results: false,
             items: Array.from({ length: 100 }, (_, index) => ({
-                title: `[Artikelkommentar][ART-101-example] Kommentar ${index + 1}`,
-                html_url: `https://github.com/dieterbaier/profile/issues/${index + 1}`
+                title: `Frei editierbarer Kommentar ${index + 1}`,
+                html_url: `https://github.com/dieterbaier/profile-artikelkommentare/issues/${index + 1}`,
+                labels: [{ name: 'Artikelkommentar' }, { name: 'ART-101-example' }]
             }))
         },
         {
@@ -70,12 +75,14 @@ test('existing comments use server-side search pagination and render matching is
             incomplete_results: false,
             items: [
                 {
-                    title: '[Artikelkommentar][ART-101-example] Kommentar 101',
-                    html_url: 'https://github.com/dieterbaier/profile/issues/101'
+                    title: 'Vollständig geänderter Titel',
+                    html_url: 'https://github.com/dieterbaier/profile-artikelkommentare/issues/101',
+                    labels: ['Artikelkommentar', 'ART-101-example']
                 },
                 {
-                    title: '[Artikelkommentar][ART-OTHER] Kein Treffer',
-                    html_url: 'https://github.com/dieterbaier/profile/issues/102'
+                    title: 'Defensiv ausgefilterter Treffer',
+                    html_url: 'https://github.com/dieterbaier/profile-artikelkommentare/issues/102',
+                    labels: [{ name: 'Artikelkommentar' }, { name: 'ART-OTHER' }]
                 }
             ]
         }
@@ -84,20 +91,21 @@ test('existing comments use server-side search pagination and render matching is
         requests.push(url);
         return { ok: true, json: async () => pages[requests.length - 1] };
     };
-    const { button, list, status } = articleComments(fetch);
+    const { button, createLink, list, status } = articleComments(fetch);
 
     // When: the reader explicitly loads existing comments
     await button.listener();
 
-    // Then: GitHub narrows by repository and title marker, all pages are read,
-    // and only exact marker matches are rendered safely as links
+    // Then: the form receives the current page URL, GitHub narrows by both
+    // stable labels, all pages are read, and only exact label matches render
+    assert.equal(new URL(createLink.href).searchParams.get('article_url'), 'http://localhost:63342/articles/example.html');
     assert.equal(requests.length, 2);
     assert.match(requests[0], /^https:\/\/api\.github\.com\/search\/issues\?/);
-    assert.match(decodeURIComponent(requests[0]), /repo:dieterbaier\/profile in:title "\[Artikelkommentar\]\[ART-101-example\]"/);
+    assert.match(decodeURIComponent(requests[0]), /repo:dieterbaier\/profile-artikelkommentare is:issue label:"Artikelkommentar" label:"ART-101-example"/);
     assert.match(requests[0], /page=1$/);
     assert.match(requests[1], /page=2$/);
     assert.equal(list.children.length, 101);
-    assert.equal(list.children[100].children[0].textContent, '[Artikelkommentar][ART-101-example] Kommentar 101');
+    assert.equal(list.children[100].children[0].textContent, 'Vollständig geänderter Titel');
     assert.equal(status.textContent, '101 Kommentare:');
     assert.equal(button.hidden, true);
 });

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -3,6 +3,7 @@
 require 'minitest/autorun'
 require 'tmpdir'
 require 'pathname'
+require 'json'
 require 'yaml'
 
 require_relative '../scripts/validate-profile-metamodel'
@@ -99,6 +100,41 @@ class ProfileCommentsTest < Minitest::Test
     assert_equal %w[comments navigation tags], generated_suffixes.sort
     generated_suffixes.each do |suffix|
       assert_includes template, "include::{docfile}/../generated/{docname}-#{suffix}.adoc[opts=optional]"
+    end
+  end
+
+  def test_only_published_website_article_ids_are_synchronized
+    # Given: published, preview, and non-website articles
+    Dir.mktmpdir('profile-comment-allowlist-test') do |dir|
+      root = Pathname.new(dir)
+      articles = [
+        ['ART-101-public', 'published', %w[website markdown-export]],
+        ['ART-102-preview', 'preview', %w[website]],
+        ['ART-103-export', 'published', %w[markdown-export]]
+      ]
+      articles.each do |id, status, channels|
+        slug = id.downcase
+        (root + 'articles').mkpath
+        (root + "articles/#{slug}.adoc").write("= #{id}\n")
+        (root + "articles/#{slug}.profile.yaml").write({
+          'id' => id,
+          'type' => 'Article',
+          'title' => id,
+          'status' => status,
+          'owner' => 'Test Owner',
+          'created' => '2026-01-01',
+          'channels' => channels,
+          'source' => "articles/#{slug}.adoc"
+        }.to_yaml)
+      end
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+
+      # When: the deployment allowlist is generated
+      path = validator.generate_article_comment_allowlist(artifacts, output: 'build/allowed-article-ids.json')
+
+      # Then: only IDs deployable to the public website are included
+      assert_equal({ 'schema_version' => 1, 'article_ids' => ['ART-101-public'] }, JSON.parse(path.read))
     end
   end
 end

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -55,8 +55,7 @@ class ProfileCommentsTest < Minitest::Test
       assert_includes generated, '[subs="attributes"]'
       assert_includes generated, '<script src="{basedir}/stylesheet/article-comments.js"></script>'
       assert_includes script, 'addEventListener("click"'
-      assert_includes script, 'issue.title.indexOf(marker)'
-      assert_includes script, 'link.textContent = issue.title'
+      assert_includes script, 'https://api.github.com/search/issues?q='
       refute_includes script, 'DOMContentLoaded'
     end
   end

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -36,8 +36,10 @@ class ProfileCommentsTest < Minitest::Test
       generated = (root + 'articles/generated/example-comments.adoc').read
 
       # Then: its link creates a GitHub issue marked with article id and title
-      assert_includes generated, 'https://github.com/dieterbaier/profile/issues/new?'
-      assert_includes generated, '%5BArtikelkommentar%5D%5BART-101-example%5D'
+      assert_includes generated, 'https://github.com/dieterbaier/profile-artikelkommentare/issues/new?'
+      assert_includes generated, 'template=artikelkommentar.yml'
+      assert_includes generated, 'article_id=ART-101-example'
+      assert_includes generated, '%5BArtikelkommentar%5D+%5BART-101-example%5D'
       assert_includes generated, 'Example+%26+Practice'
     end
   end
@@ -56,6 +58,8 @@ class ProfileCommentsTest < Minitest::Test
       assert_includes generated, '<script src="{basedir}/stylesheet/article-comments.js"></script>'
       assert_includes script, 'addEventListener("click"'
       assert_includes script, 'https://api.github.com/search/issues?q='
+      assert_includes script, 'label:\"Artikelkommentar\"'
+      assert_includes script, 'url.searchParams.set("article_url", window.location.href)'
       refute_includes script, 'DOMContentLoaded'
     end
   end

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfileCommentsTest < Minitest::Test
+  def with_article
+    Dir.mktmpdir('profile-comments-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'articles').mkpath
+      (root + 'articles/example.adoc').write("= Example & Practice\n")
+      (root + 'articles/example.profile.yaml').write({
+        'id' => 'ART-101-example',
+        'type' => 'Article',
+        'title' => 'Example & Practice',
+        'status' => 'published',
+        'owner' => 'Test Owner',
+        'created' => '2026-01-01',
+        'source' => 'articles/example.adoc'
+      }.to_yaml)
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield validator, artifacts, root
+    end
+  end
+
+  def test_each_article_receives_a_prefilled_comment_link
+    # Given: a metadata-backed article
+    with_article do |validator, artifacts, root|
+      # When: profile artifacts are generated
+      validator.generate_article_comment_includes(artifacts)
+      generated = (root + 'articles/generated/example-comments.adoc').read
+
+      # Then: its link creates a GitHub issue marked with article id and title
+      assert_includes generated, 'https://github.com/dieterbaier/profile/issues/new?'
+      assert_includes generated, '%5BArtikelkommentar%5D%5BART-101-example%5D'
+      assert_includes generated, 'Example+%26+Practice'
+    end
+  end
+
+  def test_existing_comments_can_be_requested_explicitly
+    # Given: an article comment block on the static website
+    with_article do |validator, artifacts, root|
+      validator.generate_article_comment_includes(artifacts)
+      generated = (root + 'articles/generated/example-comments.adoc').read
+      script = Pathname.new(__dir__).join('../src-content/theme/article-comments.js').read
+
+      # When: the reader requests existing comments
+      # Then: a local enhancement loads matching issues and renders linked titles
+      assert_includes generated, 'Vorhandene Kommentare laden'
+      assert_includes generated, '[subs="attributes"]'
+      assert_includes generated, '<script src="{basedir}/stylesheet/article-comments.js"></script>'
+      assert_includes script, 'addEventListener("click"'
+      assert_includes script, 'issue.title.indexOf(marker)'
+      assert_includes script, 'link.textContent = issue.title'
+      refute_includes script, 'DOMContentLoaded'
+    end
+  end
+
+  def test_non_website_article_exports_omit_the_comment_block
+    # Given: a generated article comment include
+    with_article do |validator, artifacts, root|
+      validator.generate_article_comment_includes(artifacts)
+      generated = (root + 'articles/generated/example-comments.adoc').read
+
+      # When: it is rendered without the buildsite attribute
+      # Then: AsciiDoc guards the complete interaction as website-only
+      assert_match(/ifdef::buildsite\[\].*endif::\[\]/m, generated)
+    end
+  end
+
+  def test_article_comment_styles_do_not_change_page_container_styles
+    # Given: the shared website stylesheet
+    stylesheet = Pathname.new(__dir__).join('../src-content/theme/style.css').read
+
+    # Then: page containers retain their shared layout rule, while comment
+    # presentation is defined by an independent selector.
+    assert_match(/#header,\s*#content,\s*#footnotes,\s*footer\s*\{[^}]*max-width: var\(--page-width\);/m, stylesheet)
+    assert_match(%r!/\* Optional, reader-triggered GitHub discussion for articles\. \*/\s*\.article-comments\s*\{([^}]*)\}!m, stylesheet)
+    refute_match(%r!\.article-comments\s*\{[^}]*border(?:-radius)?:!m, stylesheet)
+    refute_match(/#footnotes,\s*\/\* Optional, reader-triggered GitHub discussion for articles\. \*\/\s*\.article-comments/m, stylesheet)
+  end
+
+  def test_article_template_includes_every_generated_article_fragment
+    # Given: the article template and all per-article fragment suffixes emitted
+    # by the profile generator
+    template = Pathname.new(__dir__).join('../templates/write-article/article.adoc').read
+    generator = Pathname.new(__dir__).join('../scripts/validate-profile-metamodel.rb').read
+    generated_suffixes = generator.scan(/#\{article_slug\(article\)\}-(navigation|tags|comments)\.adoc/).flatten.uniq
+
+    # Then: new articles include every generated fragment family
+    assert_equal %w[comments navigation tags], generated_suffixes.sort
+    generated_suffixes.each do |suffix|
+      assert_includes template, "include::{docfile}/../generated/{docname}-#{suffix}.adoc[opts=optional]"
+    end
+  end
+end


### PR DESCRIPTION
Closes #44

Depends on dieterbaier/profile-artikelkommentare#1.

## What changed

- generate article-specific links to the structured issue form in `dieterbaier/profile-artikelkommentare`
- prefill article ID and title at build time and the actual page URL in the browser
- search the dedicated repository by stable comment and article-ID labels
- generate an allowlist containing only published website article IDs
- synchronize the allowlist to the comments repository before public SFTP deployment
- abort deployment when the cross-repository synchronization fails
- run article-comment behaviour tests in the PR check
- document the behaviour in Gherkin and its architecture impact

## Why

The static website gains opt-in public comments without mixing them with development issues. Stable labels survive title edits, while the deployed allowlist prevents arbitrary formal article IDs from being accepted. Synchronizing first avoids publishing an article before its ID can be validated.

## Review follow-up

- `7d32f83`: paginated server-side search and JavaScript behaviour tests
- `16bb5e2`: dedicated repository and stable label matching
- `9e5fac3`: generated and deployed semantic article-ID allowlist
- `f4ceffe`: allowlist synchronization moved before SFTP deployment
- dieterbaier/profile-artikelkommentare#1: idempotent base label, semantic validation, atomic relabeling, and directly tested workflow logic

## Verification

- `./gradlew testProfileComments` — 6 Ruby tests with 44 assertions and 2 Node behaviour tests
- `./gradlew validateProfileMetamodel` — no errors or warnings
- `./gradlew validateArchitectureMetamodel` — no errors or warnings
- `./gradlew buildSite` — successful
- `./gradlew buildArchitecture` — successful, with the pre-existing missing stylesheet warning
- changed workflow YAML parsed successfully

## Deployment prerequisite

Add an `ARTICLE_COMMENTS_REPO_TOKEN` secret to this repository with contents write access to `dieterbaier/profile-artikelkommentare`. Merge dieterbaier/profile-artikelkommentare#1 before this PR is deployed.