### PR TITLE
issue_49: Move interface terms into cascade

### DIFF
--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -60,6 +60,7 @@ class ProfileArtifactValidator
     validate_series(artifacts)
     validate_languages(artifacts)
     validate_translations(artifacts)
+    validate_ui_terms(artifacts)
     artifacts
   end
 
@@ -584,6 +585,83 @@ class ProfileArtifactValidator
     end
   end
 
+  # Interface terms must be complete per language. Content references may fall
+  # back to the default language and say so, but a menu label or a status message
+  # has nowhere to say it, so a missing key is an error rather than a fallback.
+  def validate_ui_terms(artifacts)
+    i18n_dir = profile_dir.join('includes', 'i18n')
+    return unless i18n_dir.directory?
+
+    default_path = ui_terms_path(i18n_dir, DEFAULT_LANGUAGE)
+    unless default_path.file?
+      errors << "missing interface terms for the default language: #{relative(default_path)}"
+      return
+    end
+
+    default_keys = ui_terms_keys(default_path)
+    if default_keys.empty?
+      errors << "#{relative(default_path)} defines no 'ui_*' interface terms"
+      return
+    end
+
+    languages_in_use = artifacts.map { |artifact| artifact_language(artifact) }.uniq
+
+    (LANGUAGES - [DEFAULT_LANGUAGE]).each do |language|
+      path = ui_terms_path(i18n_dir, language)
+
+      unless path.file?
+        # Only a language that content actually uses needs its interface terms.
+        errors << "#{language} content exists, but its interface terms are missing: #{relative(path)}" if languages_in_use.include?(language)
+        next
+      end
+
+      keys = ui_terms_keys(path)
+      missing = default_keys - keys
+      unknown = keys - default_keys
+
+      errors << "#{relative(path)} is missing interface term(s): #{missing.sort.join(', ')}" unless missing.empty?
+      errors << "#{relative(path)} defines interface term(s) unknown to #{relative(default_path)}: #{unknown.sort.join(', ')}" unless unknown.empty?
+    end
+
+    ([DEFAULT_LANGUAGE] + LANGUAGES).uniq.each do |language|
+      path = ui_terms_path(i18n_dir, language)
+      validate_ui_terms_format(path) if path.file?
+    end
+  end
+
+  # Interface term files are included into the AsciiDoc document header, where a
+  # blank line - and a comment line inside an include - ends the header. Anything
+  # after that point silently stops being a header attribute, which disables
+  # ':stylesheet:' and ':copycss:' and makes the site render with the default
+  # Asciidoctor theme. The symptom looks nothing like the cause, so the format is
+  # validated rather than left to memory.
+  def validate_ui_terms_format(path)
+    path.read(encoding: 'UTF-8').lines.each_with_index do |line, index|
+      next if line.match?(/\A:ui_[a-z0-9_]+:\s/)
+
+      reason = if line.strip.empty?
+                 'a blank line ends the AsciiDoc header'
+               elsif line.start_with?('//')
+                 'a comment line inside a header include ends the header'
+               else
+                 'only attribute entries are allowed'
+               end
+      errors << "#{relative(path)} line #{index + 1}: #{reason}; interface term files must contain nothing but ':ui_*:' entries"
+    end
+  end
+
+  def ui_terms_path(i18n_dir, language)
+    i18n_dir.join("ui-#{language}.adoc")
+  end
+
+  # Attribute names defined in an interface term file, ignoring comments.
+  def ui_terms_keys(path)
+    path.read(encoding: 'UTF-8').lines.filter_map do |line|
+      match = line.match(/\A:(ui_[a-z0-9_]+):/)
+      match && match[1]
+    end
+  end
+
   # Walks the translation_of chain and reports whether it revisits an artifact.
   def translation_cycle?(artifact, by_id)
     seen = [artifact.metadata['id']].compact
@@ -754,11 +832,22 @@ class ProfileArtifactValidator
                     "template=#{CGI.escape(ARTICLE_COMMENTS_TEMPLATE)}&title=#{CGI.escape(issue_title)}&" \
                     "article_id=#{CGI.escape(article_id)}&article_title=#{CGI.escape(article_title)}"
 
+    # Status wording for the browser script. The values stay AsciiDoc attribute
+    # references so the block's "subs=attributes" resolves them against the page's
+    # own interface terms, which makes the script itself free of any wording.
+    comment_terms = {
+      'i18n-empty' => '{ui_comments_empty}',
+      'i18n-loading' => '{ui_comments_loading}',
+      'i18n-error' => '{ui_comments_error}',
+      'i18n-count-one' => '{ui_comments_count_one}',
+      'i18n-count-many' => '{ui_comments_count_many}'
+    }.map { |name, value| "data-#{name}=\"#{value}\"" }.join(' ')
+
     ['// Generated article comments. Do not edit manually.',
      'ifdef::buildsite[]',
      '[subs="attributes"]',
      '++++',
-     "<section class=\"article-comments\" data-article-comments data-repository=\"#{h(ARTICLE_COMMENTS_REPOSITORY)}\" data-article-id=\"#{h(article_id)}\">",
+     "<section class=\"article-comments\" data-article-comments data-repository=\"#{h(ARTICLE_COMMENTS_REPOSITORY)}\" data-article-id=\"#{h(article_id)}\" #{comment_terms}>",
      '  <h2>Kommentare</h2>',
      '  <p>Fragen, Ergänzungen oder Feedback sind willkommen und werden als öffentliches GitHub-Issue erfasst.</p>',
      "  <p><a class=\"article-comment-create fingerPointsTo\" href=\"#{h(new_issue_url)}\" target=\"_blank\" rel=\"noopener noreferrer\">Diesen Artikel kommentieren</a></p>",

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -590,8 +590,10 @@ class ProfileArtifactValidator
   # has nowhere to say it, so a missing key is an error rather than a fallback.
   def validate_ui_terms(artifacts)
     i18n_dir = profile_dir.join('includes', 'i18n')
-    return unless i18n_dir.directory?
 
+    # Checked without testing the directory first: docheader.adoc includes the
+    # default terms unconditionally, so a missing directory breaks every page and
+    # must produce the same contract error as a missing file.
     default_path = ui_terms_path(i18n_dir, DEFAULT_LANGUAGE)
     unless default_path.file?
       errors << "missing interface terms for the default language: #{relative(default_path)}"

--- a/src-content/profile/includes/docheader.adoc
+++ b/src-content/profile/includes/docheader.adoc
@@ -4,6 +4,13 @@ endif::[]
 ifndef::lang[]
 :lang: de
 endif::[]
+// Interface terms, resolved as a cascade: the default language defines every
+// key, the page language overrides what it translates. Later assignments win in
+// AsciiDoc, so this needs no file-existence check, which AsciiDoc cannot express.
+include::./i18n/ui-de.adoc[]
+ifeval::["{lang}" != "de"]
+include::./i18n/ui-{lang}.adoc[opts=optional]
+endif::[]
 :docinfo: shared
 :docinfodir: {includesdir}/docinfo/
 ifndef::basedir[]
@@ -23,7 +30,7 @@ ifeval::["{backend}" != "pdf"]
 :imagesdir: {basedir}/assets/images/
 endif::[]
 endif::[]
-:toc-title: Inhalt
+:toc-title: {ui_toc_title}
 ifndef::toc[]
 :toc:
 endif::[]

--- a/src-content/profile/includes/docinfo/docinfo-footer.html
+++ b/src-content/profile/includes/docinfo/docinfo-footer.html
@@ -1,18 +1,18 @@
 <footer>
     <div class="footer-box smaller">
         <div class="column1">
-            <a href="{basedir}/legal.html">Rechtliches</a>
+            <a href="{basedir}/legal.html">{ui_footer_legal}</a>
         </div>
         <div class="column2">
             <div class="sustainability-note">
-                <strong>Diese Seite ist bewusst leicht gebaut.</strong><br>
-                Statisch · kein Tracking · reproduzierbare Pipeline<br>
-                <a class="fingerPointsTo" href="{basedir}/articles/architecture/sustainability.html">Warum das so ist</a>
+                <strong>{ui_footer_sustainability_title}</strong><br>
+                {ui_footer_sustainability_note}<br>
+                <a class="fingerPointsTo" href="{basedir}/articles/architecture/sustainability.html">{ui_footer_sustainability_link}</a>
             </div>
         </div>
         <div class="column3">
             {revnumber} - {revdate} <br>
-            <a href="https://architecture.dieterbaier.eu" target="_blank">Architektur der Seite</a>
+            <a href="https://architecture.dieterbaier.eu" target="_blank">{ui_footer_architecture}</a>
         </div>
     </div>
 </footer>

--- a/src-content/profile/includes/i18n/README.md
+++ b/src-content/profile/includes/i18n/README.md
@@ -1,0 +1,40 @@
+# Interface Terms
+
+`ui-<lang>.adoc` holds the user-visible interface wording per language: menu
+labels, the table-of-contents title, footer text, and the status messages the
+article-comments script renders.
+
+## How resolution works
+
+`includes/docheader.adoc` includes `ui-de.adoc` first and then, for any other
+page language, `ui-<lang>.adoc`. Later attribute assignments win in AsciiDoc, so
+the default language acts as the fallback without any file-existence check —
+something AsciiDoc cannot express on its own.
+
+Robustness comes from that cascade, completeness from validation: unlike a
+content reference, a menu label has nowhere to tell the reader that it is showing
+another language, so `validateProfileMetamodel` fails the build when a language
+in use is missing a key.
+
+## Hard formatting rule
+
+**These files may contain nothing but attribute entries — no comments, no blank
+lines.**
+
+They are included into the AsciiDoc *document header*. A blank line ends the
+header, and a comment line inside a header include ends it too. Everything after
+that point stops being a header attribute, which silently disables
+`:stylesheet:`, `:copycss:`, and `:docinfo:` — the site then renders with the
+default Asciidoctor stylesheet instead of its own. The failure looks like a
+broken theme, not like a broken include, so the validator rejects any line that
+is not an attribute entry.
+
+Document a group of keys here in this file instead of commenting the terms file.
+
+## Adding a language
+
+1. Copy `ui-de.adoc` to `ui-<lang>.adoc` and translate every value.
+2. Keep the key set identical; the validator reports missing and unknown keys.
+3. `%count%` in `ui_comments_count_many` is a placeholder the browser fills in.
+   It is deliberately not an AsciiDoc attribute reference, so it survives
+   attribute substitution untouched.

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -1,0 +1,22 @@
+:ui_nav_home: Home
+:ui_nav_cv: Curriculum Vitae
+:ui_nav_toolkit: Werkzeugkasten & Kenntnismatrix
+:ui_nav_articles: Artikel
+:ui_nav_shorts: Shorts
+:ui_nav_open: Menu öffnen
+:ui_nav_close: Menü schließen
+:ui_toc_title: Inhalt
+:ui_footer_legal: Rechtliches
+:ui_footer_sustainability_title: Diese Seite ist bewusst leicht gebaut.
+:ui_footer_sustainability_note: Statisch · kein Tracking · reproduzierbare Pipeline
+:ui_footer_sustainability_link: Warum das so ist
+:ui_footer_architecture: Architektur der Seite
+:ui_comments_heading: Kommentare
+:ui_comments_intro: Fragen, Ergänzungen oder Feedback sind willkommen und werden als öffentliches GitHub-Issue erfasst.
+:ui_comments_create: Diesen Artikel kommentieren
+:ui_comments_load: Vorhandene Kommentare laden
+:ui_comments_empty: Noch keine Kommentare vorhanden.
+:ui_comments_loading: Kommentare werden von GitHub geladen …
+:ui_comments_error: Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.
+:ui_comments_count_one: Ein Kommentar:
+:ui_comments_count_many: %count% Kommentare:

--- a/src-content/profile/includes/menue.adoc
+++ b/src-content/profile/includes/menue.adoc
@@ -9,29 +9,29 @@
 <nav id="mainnav" class="mainnav" data-active="{active}">
     <ul>
         <li>
-            <a data-nav="home" href="{basedir}/index.html">Home</a>
+            <a data-nav="home" href="{basedir}/index.html">{ui_nav_home}</a>
         </li>
     </ul>
-    <button class="nav-toggle" aria-label="Menu öffnen">☰</button>
+    <button class="nav-toggle" aria-label="{ui_nav_open}">☰</button>
     <div class="nav-drawer" id="mainnav-drawer">
-    <button class="nav-close" aria-label="Menü schließen">✕</button>
+    <button class="nav-close" aria-label="{ui_nav_close}">✕</button>
     <ul>
         <li>
 ifdef::buildsite[]
-<a data-nav="cv" href="{basedir}/cv.html">Curriculum Vitae</a>
+<a data-nav="cv" href="{basedir}/cv.html">{ui_nav_cv}</a>
 endif::[]
 ifndef::buildsite[]
-<a data-nav="cv" href="{basedir}/cv/cv.html">Curriculum Vitae</a>
+<a data-nav="cv" href="{basedir}/cv/cv.html">{ui_nav_cv}</a>
 endif::[]
         </li>
         <li>
-            <a data-nav="toolkit" href="{basedir}/architecture-toolkit.html">Werkzeugkasten & Kenntnismatrix</a>
+            <a data-nav="toolkit" href="{basedir}/architecture-toolkit.html">{ui_nav_toolkit}</a>
         </li>
         <li>
-            <a data-nav="articles" href="{basedir}/articles/articles.html">Artikel</a>
+            <a data-nav="articles" href="{basedir}/articles/articles.html">{ui_nav_articles}</a>
         </li>
         <li>
-            <a data-nav="shorts" href="{basedir}/shorts/shorts.html">Shorts</a>
+            <a data-nav="shorts" href="{basedir}/shorts/shorts.html">{ui_nav_shorts}</a>
         </li>
     </ul>
 </div>

--- a/src-content/theme/article-comments.js
+++ b/src-content/theme/article-comments.js
@@ -10,13 +10,19 @@
         link.href = url.toString();
     }
 
+    // User-visible strings come from the page, which resolves them per language
+    // through the interface term cascade. The script carries no wording of its own.
+    function term(container, key) {
+        return container.dataset[key] || "";
+    }
+
     function renderIssues(container, issues) {
         const list = container.querySelector(".article-comments-list");
         const status = container.querySelector(".article-comments-status");
         list.replaceChildren();
 
         if (issues.length === 0) {
-            status.textContent = "Noch keine Kommentare vorhanden.";
+            status.textContent = term(container, "i18nEmpty");
             return;
         }
 
@@ -30,7 +36,9 @@
             item.appendChild(link);
             list.appendChild(item);
         });
-        status.textContent = issues.length === 1 ? "Ein Kommentar:" : issues.length + " Kommentare:";
+        status.textContent = issues.length === 1
+            ? term(container, "i18nCountOne")
+            : term(container, "i18nCountMany").replace("%count%", issues.length);
     }
 
     async function loadIssues(container, button) {
@@ -44,7 +52,7 @@
             "&sort=created&order=desc&per_page=" + perPage;
 
         button.disabled = true;
-        status.textContent = "Kommentare werden von GitHub geladen …";
+        status.textContent = term(container, "i18nLoading");
 
         try {
             const issues = [];
@@ -74,7 +82,7 @@
             renderIssues(container, matchingIssues);
             button.hidden = true;
         } catch (error) {
-            status.textContent = "Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.";
+            status.textContent = term(container, "i18nError");
             button.disabled = false;
         }
     }

--- a/test/article_comments_test.mjs
+++ b/test/article_comments_test.mjs
@@ -41,9 +41,16 @@ function articleComments(fetch) {
         '.article-comments-list': list
     };
     const container = new Element('section');
+    // The page supplies every user-visible string, resolved per language through
+    // the interface term cascade; the script carries no wording of its own.
     container.dataset = {
         repository: 'dieterbaier/profile-artikelkommentare',
-        articleId: 'ART-101-example'
+        articleId: 'ART-101-example',
+        i18nEmpty: 'Noch keine Kommentare vorhanden.',
+        i18nLoading: 'Kommentare werden von GitHub geladen …',
+        i18nError: 'Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.',
+        i18nCountOne: 'Ein Kommentar:',
+        i18nCountMany: '%count% Kommentare:'
     };
     container.querySelector = selector => elements[selector];
 
@@ -54,7 +61,7 @@ function articleComments(fetch) {
     const window = { location: { href: 'http://localhost:63342/articles/example.html' } };
     vm.runInNewContext(script, { document, fetch, URL, window });
 
-    return { button, createLink, list, status };
+    return { button, container, createLink, list, status };
 }
 
 test('existing comments use server-side search pagination and render matching issues', async () => {
@@ -125,4 +132,20 @@ test('searches beyond the GitHub result limit remain retryable', async () => {
     assert.equal(status.textContent, 'Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.');
     assert.equal(button.disabled, false);
     assert.equal(button.hidden, false);
+});
+
+test('status wording follows the page language instead of the script', async () => {
+    // Given: a page that supplies English interface terms
+    const fetch = async () => ({
+        ok: true,
+        json: async () => ({ total_count: 0, incomplete_results: false, items: [] })
+    });
+    const { button, status, container } = articleComments(fetch);
+    container.dataset.i18nEmpty = 'No comments yet.';
+
+    // When: the reader loads comments and none exist
+    await button.listener();
+
+    // Then: the script renders the page's wording, not a built-in German string
+    assert.equal(status.textContent, 'No comments yet.');
 });

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -65,6 +65,25 @@ class ProfileCommentsTest < Minitest::Test
     end
   end
 
+  # The script must stay free of wording so a translated page can supply its own.
+  # The block therefore carries the status strings as attribute references, which
+  # the page resolves against its interface terms.
+  def test_comment_status_wording_comes_from_the_page_not_the_script
+    with_article do |validator, artifacts, root|
+      validator.generate_article_comment_includes(artifacts)
+      generated = (root + 'articles/generated/example-comments.adoc').read
+      script = Pathname.new(__dir__).join('../src-content/theme/article-comments.js').read
+
+      assert_includes generated, 'data-i18n-empty="{ui_comments_empty}"'
+      assert_includes generated, 'data-i18n-loading="{ui_comments_loading}"'
+      assert_includes generated, 'data-i18n-error="{ui_comments_error}"'
+      assert_includes generated, 'data-i18n-count-one="{ui_comments_count_one}"'
+      assert_includes generated, 'data-i18n-count-many="{ui_comments_count_many}"'
+      refute_match(/Kommentare werden von GitHub geladen/, script)
+      refute_match(/Noch keine Kommentare vorhanden/, script)
+    end
+  end
+
   def test_non_website_article_exports_omit_the_comment_block
     # Given: a generated article comment include
     with_article do |validator, artifacts, root|

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -18,14 +18,25 @@ require_relative '../scripts/validate-profile-metamodel'
 class ProfileLanguageTest < Minitest::Test
   DIGEST = 'a' * 64
 
+  # Every profile tree owes default interface terms, so the helper writes a
+  # minimal set unless a test states its own. Pass an empty mapping to build a
+  # tree without any interface terms at all.
+  DEFAULT_UI_TERMS = { 'de' => { 'ui_nav_home' => 'Home' } }.freeze
+
+  # Content in a second language requires that language's interface terms, so
+  # tests that publish English content supply both sets.
+  BILINGUAL_UI_TERMS = {
+    'de' => { 'ui_nav_home' => 'Home' },
+    'en' => { 'ui_nav_home' => 'Home' }
+  }.freeze
+
   # Builds an isolated profile tree from lightweight artifact descriptions and
-  # yields the validated validator. Interface term files are written when the
-  # test passes a :ui_terms mapping of language to key/value pairs.
-  def with_artifacts(artifacts, ui_terms: nil)
+  # yields the validated validator. :ui_terms maps a language to key/value pairs.
+  def with_artifacts(artifacts, ui_terms: DEFAULT_UI_TERMS)
     Dir.mktmpdir('profile-language-test') do |dir|
       root = Pathname.new(dir)
 
-      ui_terms&.each do |language, terms|
+      ui_terms.each do |language, terms|
         (root + 'includes/i18n').mkpath
         # Attribute entries only: these files are included into the document
         # header, where a comment or blank line would end it.
@@ -72,11 +83,14 @@ class ProfileLanguageTest < Minitest::Test
   # An original in the default language plus its translation in the language
   # subtree is the reference case and must validate cleanly.
   def test_accepts_original_and_translation_pair
-    with_artifacts([
-                     { id: 'ART-001-example', slug: 'example', language: 'de' },
-                     { id: 'ART-001-example-en', slug: 'example', dir: 'site/en/articles', language: 'en',
-                       translation_of: 'ART-001-example', translation_source_digest: DIGEST }
-                   ]) do |validator|
+    with_artifacts(
+      [
+        { id: 'ART-001-example', slug: 'example', language: 'de' },
+        { id: 'ART-001-example-en', slug: 'example', dir: 'site/en/articles', language: 'en',
+          translation_of: 'ART-001-example', translation_source_digest: DIGEST }
+      ],
+      ui_terms: BILINGUAL_UI_TERMS
+    ) do |validator|
       assert_empty validator.errors
     end
   end
@@ -161,11 +175,14 @@ class ProfileLanguageTest < Minitest::Test
   # German must validate, because the default language is only the fallback
   # target, not the assumed source language.
   def test_accepts_english_original_translated_into_german
-    with_artifacts([
-                     { id: 'ART-001-example-en', slug: 'example', dir: 'site/en/articles', language: 'en' },
-                     { id: 'ART-001-example', slug: 'example', language: 'de',
-                       translation_of: 'ART-001-example-en', translation_source_digest: DIGEST }
-                   ]) do |validator|
+    with_artifacts(
+      [
+        { id: 'ART-001-example-en', slug: 'example', dir: 'site/en/articles', language: 'en' },
+        { id: 'ART-001-example', slug: 'example', language: 'de',
+          translation_of: 'ART-001-example-en', translation_source_digest: DIGEST }
+      ],
+      ui_terms: BILINGUAL_UI_TERMS
+    ) do |validator|
       assert_empty validator.errors
     end
   end
@@ -250,6 +267,24 @@ class ProfileLanguageTest < Minitest::Test
       ui_terms: { 'de' => { 'ui_nav_home' => 'Home' } }
     ) do |validator|
       assert_error_matching(validator, /en content exists, but its interface terms are missing/)
+    end
+  end
+
+  # docheader.adoc includes the default terms unconditionally, so a missing
+  # directory breaks every page. It must produce the same contract error as a
+  # missing file rather than silently skipping the whole check.
+  def test_rejects_missing_interface_terms_directory
+    with_artifacts([{ id: 'ART-001-example', slug: 'example', language: 'de' }], ui_terms: {}) do |validator|
+      assert_error_matching(validator, %r{missing interface terms for the default language: includes/i18n/ui-de\.adoc})
+    end
+  end
+
+  def test_rejects_missing_default_interface_terms_file
+    with_artifacts(
+      [{ id: 'ART-001-example', slug: 'example', language: 'de' }],
+      ui_terms: { 'en' => { 'ui_nav_home' => 'Home' } }
+    ) do |validator|
+      assert_error_matching(validator, /missing interface terms for the default language/)
     end
   end
 

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -19,10 +19,19 @@ class ProfileLanguageTest < Minitest::Test
   DIGEST = 'a' * 64
 
   # Builds an isolated profile tree from lightweight artifact descriptions and
-  # yields the validated validator.
-  def with_artifacts(artifacts)
+  # yields the validated validator. Interface term files are written when the
+  # test passes a :ui_terms mapping of language to key/value pairs.
+  def with_artifacts(artifacts, ui_terms: nil)
     Dir.mktmpdir('profile-language-test') do |dir|
       root = Pathname.new(dir)
+
+      ui_terms&.each do |language, terms|
+        (root + 'includes/i18n').mkpath
+        # Attribute entries only: these files are included into the document
+        # header, where a comment or blank line would end it.
+        body = terms.map { |key, value| ":#{key}: #{value}\n" }.join
+        (root + "includes/i18n/ui-#{language}.adoc").write(body)
+      end
 
       artifacts.each do |artifact|
         slug = artifact.fetch(:slug)
@@ -186,6 +195,89 @@ class ProfileLanguageTest < Minitest::Test
   def test_rejects_mixed_language
     with_artifacts([{ id: 'ART-001-example', slug: 'example', language: 'mixed' }]) do |validator|
       assert_error_matching(validator, /unknown language 'mixed'/)
+    end
+  end
+
+  # Interface terms are the one class that must never fall back: a menu label has
+  # nowhere to tell the reader it is showing another language.
+  def test_accepts_complete_interface_terms
+    with_artifacts(
+      [{ id: 'ART-001-example', slug: 'example', language: 'de' }],
+      ui_terms: {
+        'de' => { 'ui_nav_home' => 'Home', 'ui_toc_title' => 'Inhalt' },
+        'en' => { 'ui_nav_home' => 'Home', 'ui_toc_title' => 'Contents' }
+      }
+    ) do |validator|
+      assert_empty validator.errors
+    end
+  end
+
+  def test_rejects_missing_interface_term
+    with_artifacts(
+      [{ id: 'ART-001-example', slug: 'example', language: 'de' }],
+      ui_terms: {
+        'de' => { 'ui_nav_home' => 'Home', 'ui_toc_title' => 'Inhalt' },
+        'en' => { 'ui_nav_home' => 'Home' }
+      }
+    ) do |validator|
+      assert_error_matching(validator, /ui-en\.adoc is missing interface term\(s\): ui_toc_title/)
+    end
+  end
+
+  # A key that exists only in a translation is usually a typo in the key name,
+  # which would otherwise silently render as an unresolved attribute.
+  def test_rejects_interface_term_unknown_to_the_default_language
+    with_artifacts(
+      [{ id: 'ART-001-example', slug: 'example', language: 'de' }],
+      ui_terms: {
+        'de' => { 'ui_nav_home' => 'Home' },
+        'en' => { 'ui_nav_home' => 'Home', 'ui_nav_hom' => 'Home' }
+      }
+    ) do |validator|
+      assert_error_matching(validator, /defines interface term\(s\) unknown to .*ui-de\.adoc: ui_nav_hom/)
+    end
+  end
+
+  # Content in a language without interface terms would render German chrome
+  # around a translated page, so the missing file is an error rather than a gap.
+  def test_rejects_content_language_without_interface_terms
+    with_artifacts(
+      [
+        { id: 'ART-001-example', slug: 'example', language: 'de' },
+        { id: 'ART-001-example-en', slug: 'example', dir: 'site/en/articles', language: 'en',
+          translation_of: 'ART-001-example' }
+      ],
+      ui_terms: { 'de' => { 'ui_nav_home' => 'Home' } }
+    ) do |validator|
+      assert_error_matching(validator, /en content exists, but its interface terms are missing/)
+    end
+  end
+
+  # Interface term files are included into the AsciiDoc document header, where a
+  # blank or comment line ends the header and silently disables ':stylesheet:'
+  # and ':copycss:' further down. The site then renders with the default
+  # Asciidoctor theme, so the format is validated instead of trusted.
+  def test_rejects_blank_and_comment_lines_in_interface_terms
+    Dir.mktmpdir('profile-language-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'includes/i18n').mkpath
+      (root + 'includes/i18n/ui-de.adoc').write(":ui_nav_home: Home\n\n// a group\n:ui_toc_title: Inhalt\n")
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      validator.validate
+
+      assert_error_matching(validator, /line 2: a blank line ends the AsciiDoc header/)
+      assert_error_matching(validator, /line 3: a comment line inside a header include ends the header/)
+    end
+  end
+
+  # A language nobody writes in yet needs no interface terms.
+  def test_accepts_missing_interface_terms_for_unused_language
+    with_artifacts(
+      [{ id: 'ART-001-example', slug: 'example', language: 'de' }],
+      ui_terms: { 'de' => { 'ui_nav_home' => 'Home' } }
+    ) do |validator|
+      assert_empty validator.errors
     end
   end
 end


### PR DESCRIPTION
Closes #49. Second slice of #47.

Takes the user-visible wording out of markup, footer and script and into per-language attribute files, so a second language only has to translate values. No user-visible change for German readers.

## Mechanism

`docheader.adoc` includes the default language first and the page language afterwards:

```asciidoc
include::./i18n/ui-de.adoc[]
ifeval::["{lang}" != "de"]
include::./i18n/ui-{lang}.adoc[opts=optional]
endif::[]
```

Later attribute assignments win in AsciiDoc, so the fallback needs no file-existence check — which AsciiDoc cannot express. Robustness comes from the cascade, completeness from validation: unlike a content reference, a menu label has nowhere to tell the reader it is showing another language, so a **language in use with a missing key fails the build**.

## Changes

* `src-content/profile/includes/i18n/ui-de.adoc` — complete key set (navigation, TOC title, footer, comment wording).
* `src-content/profile/includes/i18n/README.md` — how resolution works, the formatting rule, how to add a language.
* `docheader.adoc` — cascade; `:toc-title:` now keyed.
* `menue.adoc`, `docinfo/docinfo-footer.html` — literals replaced by keys.
* `theme/article-comments.js` — reads its status strings from `data-` attributes; carries no wording.
* `validate-profile-metamodel.rb` — key parity, unknown-key guard, missing-file-for-a-language-in-use, and a format check.
* Tests: 6 new validator cases, 1 new node case, 1 new generator case.

## The trap this cost an hour, now guarded

Interface term files **must contain nothing but attribute entries**. They are included into the AsciiDoc *document header*, where a blank line — and a comment line inside an include — ends the header. Everything after silently stops being a header attribute, which disabled `:stylesheet:` and `:copycss:` and rendered the whole site with the default Asciidoctor theme.

The symptom looks like a broken theme, not a broken include. So the validator now rejects any non-attribute line with a message naming the reason, and the documentation lives in the sibling `README.md` rather than in comments inside the file.

## Scope adjustment worth reviewing

#49 said the generator side of the comment strings "follows in the comments slice" (#53). Shipping only the JS half would have left the comment box with empty status messages, so the generated block now emits the five `data-i18n-*` attributes as AsciiDoc attribute references, which the page resolves against its own terms. The visible comment-block wording (heading, intro, button) stays German and remains #53's work.

## Verification

Rendered output was compared file by file against a build of `main`. The comparison method was validated first: building `main` twice produced **0 differing files**.

| Check | Result |
|---|---|
| Rendered site vs. `main` | only intended differences (below) |
| `cv.pdf` | content identical — same stream sizes, same text tokens; binary differs only in metadata after re-execution |
| `ruby -Itest test/profile_language_test.rb` | 19 runs, 26 assertions, 0 failures |
| `ruby -Itest test/profile_navigation_test.rb` | 15 runs, 55 assertions, 0 failures |
| `ruby -Itest test/profile_listings_test.rb` | 12 runs, 56 assertions, 0 failures |
| `ruby -Itest test/profile_comments_test.rb` | 7 runs, 58 assertions, 0 failures |
| `ruby -Itest test/site_metadata_injector_test.rb` | 7 runs, 18 assertions, 0 failures |
| `node --test test/article_comments_test.mjs` | 3 pass, 0 fail |
| `ruby scripts/validate-profile-metamodel.rb` | 36 artifacts, 0 errors, 0 warnings |

Intended differences in the rendered output:

1. `data-i18n-*` attributes on the comment section.
2. The rewritten `article-comments.js`.
3. `Werkzeugkasten & Kenntnismatrix` now renders as `Werkzeugkasten &amp; Kenntnismatrix`. Substituting through an attribute escapes the ampersand, which the hand-written passthrough did not. It renders identically in a browser and is valid HTML where the previous raw `&` was not — flagged because it is a real byte difference in the output.

Also spotted, deliberately preserved: the menu toggle reads `Menu öffnen` while the close button reads `Menü schließen`. Kept byte-identical as `ui_nav_open`; say the word and it becomes `Menü öffnen` in a one-line follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
