### PR TITLE
issue_50: Publish language subtree as site target

### DIFF
--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -1,0 +1,22 @@
+:ui_nav_home: Home
+:ui_nav_cv: Curriculum Vitae
+:ui_nav_toolkit: Toolbox & Skills Matrix
+:ui_nav_articles: Articles
+:ui_nav_shorts: Shorts
+:ui_nav_open: Open menu
+:ui_nav_close: Close menu
+:ui_toc_title: Contents
+:ui_footer_legal: Legal notice
+:ui_footer_sustainability_title: This site is deliberately lightweight.
+:ui_footer_sustainability_note: Static · no tracking · reproducible pipeline
+:ui_footer_sustainability_link: Why it is built this way
+:ui_footer_architecture: Architecture of this site
+:ui_comments_heading: Comments
+:ui_comments_intro: Questions, additions and feedback are welcome and are recorded as a public GitHub issue.
+:ui_comments_create: Comment on this article
+:ui_comments_load: Load existing comments
+:ui_comments_empty: No comments yet.
+:ui_comments_loading: Loading comments from GitHub …
+:ui_comments_error: Comments could not be loaded right now. Please try again later.
+:ui_comments_count_one: One comment:
+:ui_comments_count_many: %count% comments:

--- a/src-content/profile/site/en/.asciidoctorconfig.adoc
+++ b/src-content/profile/site/en/.asciidoctorconfig.adoc
@@ -1,0 +1,2 @@
+:includesdir: ../../includes
+:basedir: ../..

--- a/src-content/profile/site/en/index.adoc
+++ b/src-content/profile/site/en/index.adoc
@@ -1,0 +1,21 @@
+= Dieter Baier
+include::{includesdir}/../../revinfo.adoc[]
+:lang: en
+:revdate!:
+:revnumber!:
+:revremark: Software architect | Integration, architecture and documentation
+ifdef::buildsite[]
+:basedir: ..
+endif::[]
+:active: home
+include::{includesdir}/docheader.adoc[]
+
+[.highlight]
+--
+I help teams structure complex software systems, keep integrations manageable,
+and document and communicate architecture decisions so that they stay
+comprehensible.
+
+This English section of the site is being built up gradually. Pages that are not
+translated yet are linked in German.
+--

--- a/src-content/profile/site/en/index.adoc
+++ b/src-content/profile/site/en/index.adoc
@@ -10,12 +10,16 @@ endif::[]
 :active: home
 include::{includesdir}/docheader.adoc[]
 
+[subs=attributes,macros]
+++++
+<div class="intro">
+    <img src="{imagesdir}/dieterbaier_image_site_rounded_comic_200.png" alt="Dieter Baier">
+    <p class="introtext">I help teams structure complex software systems, keep integrations manageable, and document and communicate architecture decisions so that they remain comprehensible.</p>
+</div>
+++++
+
 [.highlight]
 --
-I help teams structure complex software systems, keep integrations manageable,
-and document and communicate architecture decisions so that they stay
-comprehensible.
-
 This English section of the site is being built up gradually. Pages that are not
 translated yet are linked in German.
 --

--- a/src-content/profile/site/en/index.profile.yaml
+++ b/src-content/profile/site/en/index.profile.yaml
@@ -1,0 +1,23 @@
+  id: PAGE-001-website-index-en
+  type: ProfilePage
+  title: "Website Index (English)"
+  status: published
+  owner: "Dieter Baier"
+  created: '2026-08-01'
+  reviewed: false
+  generated: false
+  language: en
+  translation_of: PAGE-001-website-index
+  audience:
+    - employers
+    - clients
+    - technical-community
+  channels:
+    - website
+  summary: "English landing page of the personal website."
+  summary_en: "English landing page of the personal website."
+  source: src-content/profile/site/en/index.adoc
+  tags:
+    - profile
+  relations: []
+  metadata_version: '1.0'

--- a/test/site_metadata_injector_test.rb
+++ b/test/site_metadata_injector_test.rb
@@ -55,6 +55,22 @@ class SiteMetadataInjectorTest < Minitest::Test
     end
   end
 
+  # The default language stays at the site root while every other language lives
+  # in its own subtree, so a language variant must keep its prefix in the
+  # canonical URL instead of collapsing onto the German page.
+  def test_language_subtree_pages_keep_their_language_prefix
+    with_site(%w[index.html en/index.html en/articles/example.html]) do |site|
+      injector = SiteMetadataInjector.new(site_dir: site, base_url: 'https://example.test')
+
+      injector.inject
+
+      assert_equal 'https://example.test/', canonical_href(site.join('index.html'))
+      assert_equal 'https://example.test/en/', canonical_href(site.join('en/index.html'))
+      assert_equal 'https://example.test/en/articles/example.html',
+                   canonical_href(site.join('en/articles/example.html'))
+    end
+  end
+
   def test_special_characters_in_output_paths_are_percent_encoded
     # Given: a generated public page whose output path contains spaces and non-ASCII characters
     with_site(['articles/Über uns & mehr.html']) do |site|


### PR DESCRIPTION
Closes #50. Third slice of #47.

Establishes `/en/` as a real publishing target: the default language keeps the site root, every other language mirrors the structure one level below.

## ⚠️ Merging this publishes `/en/` on dieterbaier.eu

The pilot page is a short, presentable English landing page rather than a stub, because it goes live with the next deploy. If you would rather keep the English section unpublished until the real pilot article in #57, say so and I will hold it back — the mechanism is proven either way.

## The build needed no change

Worth stating explicitly, since #50 expected build work:

* `buildSite` already renders every `.adoc` under the site source and preserves the relative path, so `site/en/index.adoc` becomes `build/site/en/index.html` on its own.
* `includesdir` is resolved from the project root, not from the page, so the extra directory level does not affect include resolution.
* What the subtree does need is the extra level in `{basedir}`, which pages set themselves inside `ifdef::buildsite[]` — the pilot page uses `:basedir: ..`.

## Changes

* `src-content/profile/site/en/index.adoc` + `index.profile.yaml` — pilot page, `language: en`, `translation_of: PAGE-001-website-index`.
* `src-content/profile/site/en/.asciidoctorconfig.adoc` — editor preview paths for the deeper level.
* `src-content/profile/includes/i18n/ui-en.adoc` — English interface terms. Required by the contract from #49 as soon as English content exists, and it exercises the cascade against a real page instead of only in tests.
* `test/site_metadata_injector_test.rb` — canonical URL guard for language subtrees.

## Verification

**German output is byte-identical.** Built `main` and this branch and compared the trees; the only difference is the added directory:

```
Only in with-en: en
```

The rendered English page, checked against the acceptance criteria:

| Criterion | Result |
|---|---|
| Published at `/en/` | `build/site/en/index.html` |
| `<html lang="en">` | ✅ |
| English chrome | `Home`, `Curriculum Vitae`, `Toolbox & Skills Matrix`, `Articles`, `Shorts`, `aria-label="Open menu"`, `Legal notice`, `Architecture of this site` |
| Assets resolve from the deeper level | all 9 `../` references resolve: `../stylesheet/style.css`, `../stylesheet/navigation.js`, `@import "../stylesheet/menuactivation.css"`, plus every nav target |
| Existing German URLs unchanged | ✅ (tree diff above) |
| Canonical URL | `https://dieterbaier.eu/en/` while the root stays `https://dieterbaier.eu/` |
| PDF and non-`buildsite` builds | `buildCVPersonal` and `buildReadme` succeed, PDFs and README produced |

| Test suite | Result |
|---|---|
| `profile_language` | 21 runs, 28 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 12 runs, 56 assertions, 0 failures |
| `profile_comments` | 7 runs, 58 assertions, 0 failures |
| `site_metadata_injector` | 8 runs, 21 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 37 artifacts, 0 errors, 0 warnings |
| Architecture validator | 55 artifacts, 0 errors, 0 warnings |

## Known and intentional for this slice

Menu and footer links on the English page point at the German pages (`../cv.html`, `../articles/articles.html`). That is the intended fallback, but it is not yet *marked* as a language change and produces no warning — both belong to the link registry in #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
