### PR TITLE
issue_53: Generate article chrome per language

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -590,12 +590,24 @@ tasks.named('buildSite') {
 // buildSite so it never competes with buildSite's stale-output cleanup, and it
 // re-runs the (idempotent) canonical URL injection so the listing pages are
 // covered as well.
-tasks.register('buildArticleListPages', org.asciidoctor.gradle.jvm.AsciidoctorTask) {
+// Languages that actually have an article source directory. The check uses the
+// committed source tree, not the generated one, so it also holds on a clean
+// checkout where generated/ does not exist yet. A second language registers its
+// own listing task as soon as its articles directory appears.
+def articleListLanguages = ['': 'src-content/profile/site/articles'] +
+        ['en'].findAll { file("src-content/profile/site/${it}/articles").isDirectory() }
+                .collectEntries { [(it): "src-content/profile/site/${it}/articles"] }
+
+articleListLanguages.each { language, articlesDir ->
+    def suffix = language.isEmpty() ? '' : language.capitalize()
+    def outputPrefix = language.isEmpty() ? '' : "${language}/"
+
+tasks.register("buildArticleListPages${suffix}", org.asciidoctor.gradle.jvm.AsciidoctorTask) {
     dependsOn tasks.named('generateProfileArtifacts')
     dependsOn tasks.named('checkEnvironment')
 
-    setSourceDir(file('src-content/profile/site/articles/generated/pages'))
-    setOutputDir(file('build/site/articles/lists'))
+    setSourceDir(file("${articlesDir}/generated/pages"))
+    setOutputDir(file("build/site/${outputPrefix}articles/lists"))
     attributes([
             'includesdir'      : 'src-content/profile/includes',
             'buildsite'        : 'true',
@@ -634,7 +646,8 @@ tasks.register('buildArticleListPages', org.asciidoctor.gradle.jvm.AsciidoctorTa
 }
 
 tasks.named('buildSite') {
-    finalizedBy tasks.named('buildArticleListPages')
+    finalizedBy tasks.named("buildArticleListPages${suffix}")
+}
 }
 
 tasks.register('testSiteMetadata') {

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -153,9 +153,23 @@ class ProfileArtifactValidator
   # <articles-dir>/generated/pages. Standalone pages are authored for the output
   # location <articles-dir>/lists, so their links resolve once the dedicated
   # Asciidoctor task renders that directory into the site. Returns written paths.
-  def generate_article_lists(artifacts, language: DEFAULT_LANGUAGE)
+  # One listing set per language, built only from that language's articles: a
+  # reader browsing the English listings should not be handed German articles.
+  #
+  # Unlike the per-article includes, these are standalone pages whose title is
+  # parsed before any interface terms are available, so the wording is baked in
+  # from the terms file rather than referenced as an attribute.
+  def generate_article_lists(artifacts)
     all_articles = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
-    articles_dir = articles_base_dir(all_articles)
+    return [] if all_articles.empty?
+
+    all_articles.group_by { |article| artifact_language(article) }.flat_map do |language, articles|
+      generate_article_lists_for(articles, language)
+    end
+  end
+
+  def generate_article_lists_for(articles, language)
+    articles_dir = articles_base_dir(articles)
     return [] if articles_dir.nil?
 
     clean_generated_lists(articles_dir)
@@ -165,9 +179,11 @@ class ProfileArtifactValidator
     FileUtils.mkdir_p(lists_dir)
     FileUtils.mkdir_p(pages_dir)
 
+    terms = ui_terms_values(language)
+
     # The output location of the standalone pages; used to compute link targets.
     output_dir = articles_dir.join('lists')
-    ordered = sort_articles(public_articles(artifacts))
+    ordered = sort_articles(public_articles(articles))
     written = []
 
     recent_path = lists_dir.join('recent.adoc')
@@ -175,20 +191,22 @@ class ProfileArtifactValidator
     written << recent_path
 
     all_path = pages_dir.join('all.adoc')
-    all_path.write(render_list_page(title: 'Alle Artikel', articles: ordered, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
+    all_path.write(render_list_page(title: terms.fetch('ui_article_list_all'), articles: ordered, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
     written << all_path
 
     tags_in_use(ordered).each do |tag|
       tagged = ordered.select { |article| Array(article.metadata['tags']).include?(tag) }
       path = pages_dir.join("tag-#{tag}.adoc")
-      path.write(render_list_page(title: "Artikel mit dem Tag: #{tag}", articles: tagged, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
+      title = "#{terms.fetch('ui_article_list_tag_prefix')} #{tag}"
+      path.write(render_list_page(title: title, articles: tagged, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
       written << path
     end
 
     skills_in_use(ordered).each do |skill|
       skilled = ordered.select { |article| Array(article.metadata['skills']).include?(skill) }
       path = pages_dir.join("skill-#{skill}.adoc")
-      path.write(render_list_page(title: "Artikel zum Thema: #{humanize_slug(skill)}", articles: skilled, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
+      title = "#{terms.fetch('ui_article_list_skill_prefix')} #{humanize_slug(skill)}"
+      path.write(render_list_page(title: title, articles: skilled, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
       written << path
     end
 
@@ -923,6 +941,23 @@ class ProfileArtifactValidator
     i18n_dir.join("ui-#{language}.adoc")
   end
 
+  # Interface terms as values, resolved the same way the AsciiDoc cascade does:
+  # the default language defines every key, the page language overrides what it
+  # translates. Used where a value has to be baked into generated output because
+  # no page header is available to resolve an attribute reference.
+  def ui_terms_values(language)
+    i18n_dir = profile_dir.join('includes', 'i18n')
+    [DEFAULT_LANGUAGE, language].uniq.each_with_object({}) do |candidate, terms|
+      path = ui_terms_path(i18n_dir, candidate)
+      next unless path.file?
+
+      path.read(encoding: 'UTF-8').lines.each do |line|
+        match = line.match(/\A:(ui_[a-z0-9_]+):\s+(\S.*?)\s*\z/)
+        terms[match[1]] = match[2] if match
+      end
+    end
+  end
+
   # Attribute names defined in an interface term file, ignoring comments.
   def ui_terms_keys(path)
     path.read(encoding: 'UTF-8').lines.filter_map do |line|
@@ -1117,10 +1152,10 @@ class ProfileArtifactValidator
      '[subs="attributes"]',
      '++++',
      "<section class=\"article-comments\" data-article-comments data-repository=\"#{h(ARTICLE_COMMENTS_REPOSITORY)}\" data-article-id=\"#{h(article_id)}\" #{comment_terms}>",
-     '  <h2>Kommentare</h2>',
-     '  <p>Fragen, Ergänzungen oder Feedback sind willkommen und werden als öffentliches GitHub-Issue erfasst.</p>',
-     "  <p><a class=\"article-comment-create fingerPointsTo\" href=\"#{h(new_issue_url)}\" target=\"_blank\" rel=\"noopener noreferrer\">Diesen Artikel kommentieren</a></p>",
-     '  <button class="article-comments-load" type="button">Vorhandene Kommentare laden</button>',
+     '  <h2>{ui_comments_heading}</h2>',
+     '  <p>{ui_comments_intro}</p>',
+     "  <p><a class=\"article-comment-create fingerPointsTo\" href=\"#{h(new_issue_url)}\" target=\"_blank\" rel=\"noopener noreferrer\">{ui_comments_create}</a></p>",
+     '  <button class="article-comments-load" type="button">{ui_comments_load}</button>',
      '  <p class="article-comments-status" aria-live="polite"></p>',
      '  <ul class="article-comments-list"></ul>',
      '</section>',
@@ -1151,8 +1186,11 @@ class ProfileArtifactValidator
 
     lines = []
     lines << '// Generated article navigation. Do not edit manually.'
+    # The wording comes from the interface terms of the page this include
+    # lands on, so a translated article gets translated navigation.
+    lines << '[subs="attributes"]'
     lines << '++++'
-    lines << '<nav class="article-nav" aria-label="Artikel-Navigation">'
+    lines << '<nav class="article-nav" aria-label="{ui_article_nav_label}">'
     lines.concat(sections)
     lines << '</nav>'
     lines << '++++'
@@ -1166,7 +1204,7 @@ class ProfileArtifactValidator
     href = h(article_link_href(from_article, target))
     title = h(target.metadata['title'])
     "  <div class=\"article-nav-prev\">\n" \
-      "    <a href=\"#{href}\" rel=\"prev\"><span class=\"article-nav-label\">&#8592; (Serie) Vorheriger Artikel</span>" \
+      "    <a href=\"#{href}\" rel=\"prev\"><span class=\"article-nav-label\">&#8592; {ui_article_nav_prev}</span>" \
       "<span class=\"article-nav-title\">#{title}</span></a>\n" \
       '  </div>'
   end
@@ -1177,7 +1215,7 @@ class ProfileArtifactValidator
     href = h(article_link_href(from_article, target))
     title = h(target.metadata['title'])
     "  <div class=\"article-nav-next\">\n" \
-      "    <a href=\"#{href}\" rel=\"next\"><span class=\"article-nav-label\">(Serie) Nächster Artikel &#8594;</span>" \
+      "    <a href=\"#{href}\" rel=\"next\"><span class=\"article-nav-label\">{ui_article_nav_next} &#8594;</span>" \
       "<span class=\"article-nav-title\">#{title}</span></a>\n" \
       '  </div>'
   end
@@ -1185,11 +1223,13 @@ class ProfileArtifactValidator
   def nav_related_html(from_article, related)
     return nil if related.empty?
 
+    page_language = artifact_language(from_article)
     items = related.map do |target|
-      "      <li><a href=\"#{h(article_link_href(from_article, target))}\">#{h(target.metadata['title'])}</a></li>"
+      marker = artifact_language(target) == page_language ? '' : "&#160;(#{artifact_language(target)})"
+      "      <li><a href=\"#{h(article_link_href(from_article, target))}\">#{h(target.metadata['title'])}#{marker}</a></li>"
     end
     ['  <div class="article-nav-related">',
-     '    <span class="article-nav-heading">Könnte Sie auch interessieren</span>',
+     '    <span class="article-nav-heading">{ui_article_nav_related}</span>',
      '    <ul>',
      *items,
      '    </ul>',
@@ -1214,9 +1254,34 @@ class ProfileArtifactValidator
       { article: candidate, linked: is_linked, shared: shared }
     end
 
-    scored.sort_by do |entry|
+    ranked = scored.sort_by do |entry|
       [entry[:linked] ? 0 : 1, -entry[:shared], -date_ordinal(entry[:article]), entry[:article].metadata['id'].to_s]
-    end.first(RELATED_LIMIT).map { |entry| entry[:article] }
+    end.map { |entry| entry[:article] }
+
+    prefer_same_language(ranked, artifact_language(article), all_articles).first(RELATED_LIMIT)
+  end
+
+  # Recommendations are resolved like page references: the same-language variant
+  # of a suggested article wins, and a suggestion that exists only in the default
+  # language is still offered rather than dropped - a reader can follow it, and
+  # the link says which language it leads to.
+  def prefer_same_language(articles, language, all_articles)
+    groups = all_articles.group_by { |candidate| translation_group_key(candidate) }
+    seen = Set.new
+
+    articles.filter_map do |candidate|
+      key = translation_group_key(candidate)
+      next unless seen.add?(key)
+
+      variant = groups.fetch(key, []).find { |sibling| artifact_language(sibling) == language }
+      variant || candidate
+    end
+  end
+
+  # Articles that are translations of one another share a group key, so a
+  # suggestion can be swapped for its variant in the reader's language.
+  def translation_group_key(article)
+    article.metadata['translation_of'] || article.metadata['id']
   end
 
   def related_relation_ids(article, all_articles)

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -20,3 +20,10 @@
 :ui_comments_error: Kommentare konnten derzeit nicht geladen werden. Bitte versuchen Sie es später erneut.
 :ui_comments_count_one: Ein Kommentar:
 :ui_comments_count_many: %count% Kommentare:
+:ui_article_nav_label: Artikel-Navigation
+:ui_article_nav_prev: (Serie) Vorheriger Artikel
+:ui_article_nav_next: (Serie) Nächster Artikel
+:ui_article_nav_related: Könnte Sie auch interessieren
+:ui_article_list_all: Alle Artikel
+:ui_article_list_tag_prefix: Artikel mit dem Tag:
+:ui_article_list_skill_prefix: Artikel zum Thema:

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -20,3 +20,10 @@
 :ui_comments_error: Comments could not be loaded right now. Please try again later.
 :ui_comments_count_one: One comment:
 :ui_comments_count_many: %count% comments:
+:ui_article_nav_label: Article navigation
+:ui_article_nav_prev: (Series) Previous article
+:ui_article_nav_next: (Series) Next article
+:ui_article_nav_related: You might also be interested in
+:ui_article_list_all: All articles
+:ui_article_list_tag_prefix: Articles tagged:
+:ui_article_list_skill_prefix: Articles about:

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -54,7 +54,7 @@ class ProfileCommentsTest < Minitest::Test
 
       # When: the reader requests existing comments
       # Then: a local enhancement loads matching issues and renders linked titles
-      assert_includes generated, 'Vorhandene Kommentare laden'
+      assert_includes generated, '{ui_comments_load}'
       assert_includes generated, '[subs="attributes"]'
       assert_includes generated, '<script src="{basedir}/stylesheet/article-comments.js"></script>'
       assert_includes script, 'addEventListener("click"'

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -11,6 +11,7 @@
 require 'minitest/autorun'
 require 'tmpdir'
 require 'pathname'
+require 'json'
 require 'yaml'
 
 require_relative '../scripts/validate-profile-metamodel'
@@ -28,6 +29,22 @@ class ProfileLanguageTest < Minitest::Test
   BILINGUAL_UI_TERMS = {
     'de' => { 'ui_nav_home' => 'Home' },
     'en' => { 'ui_nav_home' => 'Home' }
+  }.freeze
+
+  # Listing titles are baked into generated pages, so those tests need the
+  # terms the generator reads.
+  LIST_TERMS_DE = {
+    'ui_nav_home' => 'Home',
+    'ui_article_list_all' => 'Alle Artikel',
+    'ui_article_list_tag_prefix' => 'Artikel mit dem Tag:',
+    'ui_article_list_skill_prefix' => 'Artikel zum Thema:'
+  }.freeze
+
+  LIST_TERMS_EN = {
+    'ui_nav_home' => 'Home',
+    'ui_article_list_all' => 'All articles',
+    'ui_article_list_tag_prefix' => 'Articles tagged:',
+    'ui_article_list_skill_prefix' => 'Articles about:'
   }.freeze
 
   # Builds an isolated profile tree from lightweight artifact descriptions and
@@ -69,7 +86,7 @@ class ProfileLanguageTest < Minitest::Test
       'created' => '2026-01-01',
       'source' => source_rel
     }
-    %i[language translation_of translation_source_digest translation_divergence].each do |field|
+    %i[language translation_of translation_source_digest translation_divergence tags channels].each do |field|
       metadata[field.to_s] = artifact[field] if artifact.key?(field)
     end
     metadata.to_yaml
@@ -460,6 +477,105 @@ class ProfileLanguageTest < Minitest::Test
       assert_empty validator.errors
       assert validator.warnings.any? { |warning| warning.match?(/en: 1 of 1 content fragment/) },
              "expected a coverage warning, got: #{validator.warnings.inspect}"
+    end
+  end
+
+  # Listings are built per language: a reader browsing the English listings
+  # should not be handed German articles.
+  def test_article_listings_are_generated_per_language
+    with_artifacts(
+      [
+        { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+        { id: 'ART-001-en', slug: 'first', dir: 'site/en/articles', language: 'en', tags: %w[architecture],
+          translation_of: 'ART-001-de' }
+      ],
+      ui_terms: {
+        'de' => LIST_TERMS_DE,
+        'en' => LIST_TERMS_EN
+      }
+    ) do |validator, root, artifacts|
+      validator.generate_article_lists(artifacts)
+
+      german = (root + 'site/articles/generated/pages/all.adoc').read
+      english = (root + 'site/en/articles/generated/pages/all.adoc').read
+
+      # Each listing is titled in its own language and lists only its own articles.
+      assert_includes german, '= Alle Artikel'
+      assert_includes german, 'first.html'
+      refute_includes german, 'en/articles'
+
+      assert_includes english, '= All articles'
+      assert_includes english, 'first.html'
+
+      assert_includes (root + 'site/en/articles/generated/pages/tag-architecture.adoc').read, '= Articles tagged: architecture'
+      assert_includes (root + 'site/articles/generated/pages/tag-architecture.adoc').read, '= Artikel mit dem Tag: architecture'
+    end
+  end
+
+  # Article chrome resolves its wording through the page it lands on, so a
+  # translated article gets translated navigation without a second generator pass.
+  def test_article_chrome_wording_is_resolved_by_the_page
+    with_artifacts(
+      [
+        { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+        { id: 'ART-002-de', slug: 'second', dir: 'site/articles', language: 'de', tags: %w[architecture] }
+      ]
+    ) do |validator, root, artifacts|
+      validator.generate_article_navigation(artifacts)
+      validator.generate_article_comment_includes(artifacts)
+
+      navigation = (root + 'site/articles/generated/first-navigation.adoc').read
+      comments = (root + 'site/articles/generated/first-comments.adoc').read
+
+      assert_includes navigation, '[subs="attributes"]'
+      assert_includes navigation, 'aria-label="{ui_article_nav_label}"'
+      assert_includes navigation, '{ui_article_nav_related}'
+      assert_includes comments, '{ui_comments_heading}'
+      assert_includes comments, '{ui_comments_create}'
+      refute_match(/Könnte Sie auch interessieren|Kommentare<|Diesen Artikel kommentieren/, navigation + comments)
+    end
+  end
+
+  # A recommendation is swapped for its variant in the reader's language, and one
+  # that exists only in the default language is still offered - marked.
+  def test_related_articles_prefer_the_page_language_and_mark_the_rest
+    with_artifacts(
+      [
+        { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+        { id: 'ART-001-en', slug: 'first', dir: 'site/en/articles', language: 'en', tags: %w[architecture],
+          translation_of: 'ART-001-de' },
+        { id: 'ART-002-de', slug: 'second', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+        { id: 'ART-003-en', slug: 'third', dir: 'site/en/articles', language: 'en', tags: %w[architecture] }
+      ],
+      ui_terms: BILINGUAL_UI_TERMS
+    ) do |validator, root, artifacts|
+      validator.generate_article_navigation(artifacts)
+      english = (root + 'site/en/articles/generated/third-navigation.adoc').read
+
+      # The English variant of ART-001 wins over its German original, unmarked.
+      assert_includes english, 'first.html'
+      # ART-002 exists in German only and is offered with its language marked.
+      assert_match(/second\.html">[^<]*&#160;\(de\)</, english)
+    end
+  end
+
+  # Each language variant is its own artifact, so its comment thread and its
+  # allowlist entry follow from its own ID without any extra rule.
+  def test_comment_threads_are_separate_per_language_variant
+    with_artifacts(
+      [
+        { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', channels: %w[website] },
+        { id: 'ART-001-en', slug: 'first', dir: 'site/en/articles', language: 'en', channels: %w[website],
+          translation_of: 'ART-001-de' }
+      ],
+      ui_terms: BILINGUAL_UI_TERMS
+    ) do |validator, root, artifacts|
+      validator.generate_article_comment_includes(artifacts)
+      allowlist = validator.generate_article_comment_allowlist(artifacts, output: 'build/allowed.json')
+
+      assert_includes (root + 'site/articles/generated/first-comments.adoc').read, 'data-article-id="ART-001-de"'
+      assert_includes (root + 'site/en/articles/generated/first-comments.adoc').read, 'data-article-id="ART-001-en"'
+      assert_equal %w[ART-001-de ART-001-en], JSON.parse(allowlist.read)['article_ids']
     end
   end
 

--- a/test/profile_listings_test.rb
+++ b/test/profile_listings_test.rb
@@ -23,6 +23,15 @@ class ProfileListingsTest < Minitest::Test
     Dir.mktmpdir('profile-list-test') do |dir|
       root = Pathname.new(dir)
 
+      # Listing titles are baked in from the interface terms, so every profile
+      # tree needs them - the same contract the validator enforces.
+      (root + 'includes/i18n').mkpath
+      (root + 'includes/i18n/ui-de.adoc').write(
+        ":ui_article_list_all: Alle Artikel\n" \
+        ":ui_article_list_tag_prefix: Artikel mit dem Tag:\n" \
+        ":ui_article_list_skill_prefix: Artikel zum Thema:\n"
+      )
+
       articles.each do |article|
         slug = article.fetch(:slug)
         rel_dir = article.fetch(:dir, 'articles')
@@ -171,8 +180,9 @@ class ProfileListingsTest < Minitest::Test
     ]
 
     with_articles(articles) do |validator, artifacts, root|
-      # When: the article lists are generated in German (the default)
-      validator.generate_article_lists(artifacts, language: 'de')
+      # When: the article lists are generated; the language now follows each
+      # article's own metadata instead of a parameter
+      validator.generate_article_lists(artifacts)
 
       # Then: the first shows the German summary and the second falls back to neutral
       entry = recent(root)

--- a/test/profile_navigation_test.rb
+++ b/test/profile_navigation_test.rb
@@ -112,7 +112,7 @@ class ProfileNavigationTest < Minitest::Test
       # Then: each article lists the other under the related heading
       alpha = nav_for(root, 'alpha')
       beta = nav_for(root, 'beta')
-      assert_includes alpha, 'Könnte Sie auch interessieren'
+      assert_includes alpha, '{ui_article_nav_related}'
       assert_includes alpha, 'href="beta.html"'
       assert_includes beta, 'href="alpha.html"'
     end
@@ -192,7 +192,7 @@ class ProfileNavigationTest < Minitest::Test
       # Then: only the previous section is rendered, with the (Serie) label
       second = nav_for(root, 'second')
       assert_includes second, 'article-nav-prev'
-      assert_includes second, '(Serie) Vorheriger Artikel'
+      assert_includes second, '{ui_article_nav_prev}'
       refute_includes second, 'article-nav-related'
       refute_includes second, 'article-nav-next'
     end


### PR DESCRIPTION
Closes #53. Sixth slice of #47.

Gives the per-article includes and the article listings a language dimension.

## Two mechanisms, for a reason

**Per-article includes reference, listing pages bake.**

Navigation, tags and comments are includes that land on an article page, so their wording can stay `{ui_*}` references resolved by that page's own cascade — one generated file serves any language it is included into.

Listing pages are standalone: their title is the first line and is parsed before any header attribute exists. An attribute reference there would render literally. So the generator reads the terms file itself and bakes the value in, resolving `de` then the target language exactly like the AsciiDoc cascade does.

## Changes

* `validate-profile-metamodel.rb`
  * navigation and comment blocks use `{ui_article_nav_*}` / `{ui_comments_*}`; the navigation block gained `[subs="attributes"]`
  * `generate_article_lists` groups articles by language and emits one listing set per language, titled from that language's terms
  * related articles are swapped for their same-language variant; one that exists only in the default language is offered with a `(de)` marker rather than dropped
  * `ui_terms_values` — the cascade, resolved in Ruby for baked values
* `ui-de.adoc` / `ui-en.adoc` — 7 new keys for article chrome
* `build.gradle` — the listing render task is registered per language, driven by the **committed** article source directory rather than the generated one, so it also holds on a clean checkout. A second language registers its own task as soon as `site/<lang>/articles/` exists.

## Arrows and ampersands stayed in the template

`&#8592;` and `&#8594;` remain in the generator, not in the terms: an attribute value is escaped on substitution, so an entity there would render as `&amp;#8592;`. Only the words moved.

## Comment threads came out free

Each language variant is already its own artifact with its own ID (#48), so separate threads and their allowlist entries need no extra rule — `data-article-id` follows the variant, and the allowlist simply covers more IDs. Covered by a test.

## Verification

**German output byte-identical** across site, readme and CV:

```
Only in build/site: en
```

| Check | Result |
|---|---|
| `profile_language` | 33 runs, 97 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 12 runs, 56 assertions, 0 failures |
| `profile_comments` | 7 runs, 58 assertions, 0 failures |
| `site_metadata_injector` | 8 runs, 21 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 0 errors |
| Architecture validator | 55 artifacts, 0 errors, 0 warnings |

Four new tests cover per-language listings, reference-based chrome wording, language-preferring recommendations, and separate comment threads.

## Three existing test suites needed updating — all intended

* `profile_navigation` and `profile_comments` asserted German literals that are now attribute references.
* `profile_listings` fixtures built trees without interface terms; since listing titles are baked from them, every profile tree now owes them — the same contract the validator enforces. One test also passed `language:` to `generate_article_lists`, which no longer takes it: the language follows each article's own metadata.

## Note on scope

There are no English articles yet, so the per-language listing task has nothing to render on the real site and the English chrome is proven by tests rather than by a rendered page. That is #57's job, and it is the point at which the second listing task starts registering itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
