### PR TITLE
issue_54: Show translation provenance to readers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -435,6 +435,19 @@ tasks.register('testProfileLanguage') {
     }
 }
 
+tasks.register('testProfileTranslation') {
+    description = 'Runs the translation provenance behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_translation_test.rb')
+    inputs.files('features/article-translation-provenance.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_translation_test.rb'
+        }
+    }
+}
+
 tasks.register('testProfileListings') {
     description = 'Runs the article listing generator behaviour tests.'
     group = 'verification'

--- a/features/article-translation-provenance.feature
+++ b/features/article-translation-provenance.feature
@@ -1,0 +1,55 @@
+# Living documentation for translation provenance: telling a reader that the
+# article they are on is a translation, which text it came from, and whether it
+# still matches that text.
+#
+# Bridged to: test/profile_translation_test.rb (classic Minitest, no native BDD
+# runner in this repository). Each scenario maps to at least one automated test
+# method named after the sanitized scenario title, with Given/When/Then comment
+# anchors inside it. Traceability is a reviewer-verifiable convention, not a
+# build-enforced link.
+#
+# Default language and original language are separate concepts: 'de' is the
+# fallback target for missing translations, while the original is whatever
+# language the article was written in first. An article written in English and
+# translated into German afterwards is an English original.
+
+Feature: Article translation provenance
+  As a reader of a translated article
+  I want to see that it is a translation and whether it still matches its original
+  So that I can judge how current and complete the text in front of me is
+
+  Scenario: Original article shows no provenance note
+    Given an article that was not translated from another article
+    When the translation notes are generated
+    Then its translation note file is empty
+
+  Scenario: Translation names the article it came from
+    Given a translation whose recorded digest matches its original
+    When the translation notes are generated
+    Then its note states that the article is a translation and links to the original
+
+  Scenario: Changed original marks its translations as outdated
+    Given a translation whose original has changed since the translation was written
+    When the translation notes are generated
+    Then its note additionally states that the original has changed
+    And the outdated translation is reported to the author
+
+  Scenario: Outdated translation stays publishable
+    Given a translation whose original has changed since the translation was written
+    When the profile metadata is validated
+    Then validation reports no error
+
+  Scenario: Re-accepting the original clears the outdated note
+    Given a translation whose original has changed since the translation was written
+    When the author re-accepts the current original for that translation
+    Then its note no longer states that the original has changed
+
+  Scenario: Deliberate divergence is shown even when the translation is in sync
+    Given a translation that declares a deliberate difference from its original
+    When the translation notes are generated
+    Then its note states that the content differs from the original
+
+  Scenario: Outdated and deliberately different are shown together
+    Given a translation that declares a deliberate difference and whose original has changed
+    When the translation notes are generated
+    Then its note states both that the original has changed and that the content differs

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -3,6 +3,7 @@
 
 require 'cgi'
 require 'date'
+require 'digest'
 require 'fileutils'
 require 'json'
 require 'optparse'
@@ -211,6 +212,134 @@ class ProfileArtifactValidator
     end
 
     written
+  end
+
+  # Writes one provenance note per article next to it, empty for originals.
+  # A translation always says what it came from; an outdated or deliberately
+  # divergent one additionally says how it relates to that text. Both notes can
+  # appear together, because staleness and intent are independent.
+  def generate_translation_notes(artifacts)
+    articles = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
+    by_id = index_by_id(artifacts)
+
+    clean_generated_translation_notes
+
+    articles.map do |article|
+      notes_dir = article_source_path(article).dirname.join('generated')
+      FileUtils.mkdir_p(notes_dir)
+      path = notes_dir.join("#{article_slug(article)}-translation.adoc")
+      path.write(render_translation_note(article, by_id), encoding: 'UTF-8')
+      path
+    end
+  end
+
+  # The freshness of a translation, derived by comparing the digest recorded at
+  # translation time against the original's current source. The derived state is
+  # a default, not a verdict: re-accepting the original clears it, which is the
+  # intended answer to a cosmetic change such as a typo fix.
+  def translation_state(article, by_id)
+    original_id = article.metadata['translation_of']
+    return nil if blank?(original_id)
+
+    original = by_id[original_id]
+    return nil if original.nil?
+
+    recorded = article.metadata['translation_source_digest']
+    outdated = !blank?(recorded) && recorded != source_digest(original)
+
+    {
+      original: original,
+      outdated: outdated,
+      divergent: !blank?(article.metadata['translation_divergence']),
+      untracked: blank?(recorded)
+    }
+  end
+
+  # Digest of an artifact's full source. The whole file counts, because a change
+  # anywhere in it can change what the text says.
+  def source_digest(artifact)
+    path = article_source_path(artifact)
+    return nil unless path.file?
+
+    Digest::SHA256.hexdigest(path.read(encoding: 'UTF-8'))
+  end
+
+  def render_translation_note(article, by_id)
+    state = translation_state(article, by_id)
+    return '' if state.nil?
+
+    href = h(article_link_href(article, state[:original]))
+    title = h(state[:original].metadata['title'])
+
+    lines = ['// Generated translation provenance. Do not edit manually.',
+             '[subs="attributes"]',
+             '++++',
+             '<aside class="translation-note">',
+             "  <p>{ui_translation_of} <a href=\"#{href}\">#{title}</a>.</p>"]
+    lines << '  <p>{ui_translation_outdated}</p>' if state[:outdated]
+    lines << '  <p>{ui_translation_divergent}</p>' if state[:divergent]
+    lines.concat(['</aside>', '++++', ''])
+    lines.join("\n")
+  end
+
+  def clean_generated_translation_notes
+    Dir.glob(profile_dir.join('**', 'generated', '*-translation.adoc').to_s).each do |path|
+      File.delete(path)
+    end
+  end
+
+  # Outdated translations stay publishable, so they are reported to the author
+  # rather than failing the build.
+  def report_translation_states(artifacts)
+    by_id = index_by_id(artifacts)
+
+    artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }.each do |article|
+      state = translation_state(article, by_id)
+      next if state.nil?
+
+      location = relative(article.path)
+      warnings << "#{location} is outdated: its original '#{state[:original].metadata['id']}' changed since " \
+                  'the translation was accepted' if state[:outdated]
+      warnings << "#{location} is a translation without a recorded 'translation_source_digest', so its " \
+                  'freshness cannot be checked' if state[:untracked]
+    end
+  end
+
+  # Records the original's current source digest for a translation without
+  # touching the translation itself. This is the author override: it declares
+  # that the change in the original needed no change here.
+  def accept_translation(artifacts, artifact_id)
+    by_id = index_by_id(artifacts)
+    article = by_id[artifact_id]
+    raise ArgumentError, "unknown artifact '#{artifact_id}'" if article.nil?
+
+    original_id = article.metadata['translation_of']
+    raise ArgumentError, "'#{artifact_id}' is not a translation" if blank?(original_id)
+
+    original = by_id[original_id]
+    raise ArgumentError, "unknown original '#{original_id}'" if original.nil?
+
+    digest = source_digest(original)
+    raise ArgumentError, "original '#{original_id}' has no readable source" if digest.nil?
+
+    write_translation_digest(article, digest)
+  end
+
+  # The digest lives in the sidecar next to the translation, or in the front
+  # matter when the artifact carries its metadata inline.
+  def write_translation_digest(article, digest)
+    path = article.path
+    text = path.read(encoding: 'UTF-8')
+    entry = "translation_source_digest: #{digest}"
+
+    updated = if text.match?(/^(\s*)translation_source_digest:.*$/)
+                text.sub(/^(\s*)translation_source_digest:.*$/) { "#{Regexp.last_match(1)}#{entry}" }
+              else
+                text.sub(/^(\s*)translation_of:.*$/) { "#{Regexp.last_match(0)}\n#{Regexp.last_match(1)}#{entry}" }
+              end
+
+    path.write(updated, encoding: 'UTF-8')
+    path
   end
 
   # Writes one link registry per language into a generated include. Chrome and
@@ -1406,7 +1535,8 @@ if $PROGRAM_NAME == __FILE__
     profile_dir: nil,
     generate: false,
     output: nil,
-    article_comment_allowlist: nil
+    article_comment_allowlist: nil,
+    accept_translation: nil
   }
   OptionParser.new do |parser|
     parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
@@ -1414,6 +1544,7 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--generate') { options[:generate] = true }
     parser.on('--output PATH') { |value| options[:output] = value }
     parser.on('--article-comment-allowlist PATH') { |value| options[:article_comment_allowlist] = value }
+    parser.on('--accept-translation ID') { |value| options[:accept_translation] = value }
   end.parse!
 
   root = options[:root]
@@ -1424,6 +1555,12 @@ if $PROGRAM_NAME == __FILE__
   artifacts = validator.validate
   validator.report(artifacts)
   exit(1) unless validator.errors.empty?
+
+  if options[:accept_translation]
+    path = validator.accept_translation(artifacts, options[:accept_translation])
+    puts "Accepted current original for #{options[:accept_translation]}: #{path.relative_path_from(root)}"
+    exit(0)
+  end
 
   warnings_before_generate = validator.warnings.length
   if options[:generate]
@@ -1442,8 +1579,11 @@ if $PROGRAM_NAME == __FILE__
     puts "Generated article comment allowlist: #{allowlist_path.relative_path_from(root)}"
     list_paths = validator.generate_article_lists(artifacts)
     puts "Generated #{list_paths.length} article list file(s)."
+    note_paths = validator.generate_translation_notes(artifacts)
+    puts "Generated #{note_paths.length} translation note(s)."
     registry_paths = validator.generate_link_registries(artifacts)
     puts "Generated #{registry_paths.length} link registry file(s)."
+    validator.report_translation_states(artifacts)
     validator.report_warnings(since: warnings_before_generate)
   end
 end

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -27,3 +27,6 @@
 :ui_article_list_all: Alle Artikel
 :ui_article_list_tag_prefix: Artikel mit dem Tag:
 :ui_article_list_skill_prefix: Artikel zum Thema:
+:ui_translation_of: Das ist eine Übersetzung vom Originalartikel
+:ui_translation_outdated: Der Originalartikel wurde seit dieser Übersetzung geändert.
+:ui_translation_divergent: Dieser Text weicht inhaltlich bewusst vom Original ab.

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -27,3 +27,6 @@
 :ui_article_list_all: All articles
 :ui_article_list_tag_prefix: Articles tagged:
 :ui_article_list_skill_prefix: Articles about:
+:ui_translation_of: This is a translation of the original article
+:ui_translation_outdated: The original article has changed since this translation was written.
+:ui_translation_divergent: This text deliberately differs in content from the original.

--- a/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
+++ b/src-content/profile/site/articles/architecture/smarte-cicd-pipeline.adoc
@@ -14,6 +14,8 @@ include::{includesdir}/docheader.adoc[]
 
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-tags.adoc[opts=optional]
+// Generated translation provenance; empty unless the article is a translation.
+include::{docfile}/../generated/{docname}-translation.adoc[opts=optional]
 endif::[]
 
 toc::[]

--- a/src-content/profile/site/articles/architecture/sustainability.adoc
+++ b/src-content/profile/site/articles/architecture/sustainability.adoc
@@ -14,6 +14,8 @@ include::{includesdir}/docheader.adoc[]
 
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-tags.adoc[opts=optional]
+// Generated translation provenance; empty unless the article is a translation.
+include::{docfile}/../generated/{docname}-translation.adoc[opts=optional]
 endif::[]
 
 [.highlight.info]

--- a/src-content/profile/site/articles/documentation/doc-as-code.adoc
+++ b/src-content/profile/site/articles/documentation/doc-as-code.adoc
@@ -13,6 +13,8 @@ include::{includesdir}/docheader.adoc[]
 
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-tags.adoc[opts=optional]
+// Generated translation provenance; empty unless the article is a translation.
+include::{docfile}/../generated/{docname}-translation.adoc[opts=optional]
 endif::[]
 
 :include_next_articles_variante1: false

--- a/templates/write-article/article.adoc
+++ b/templates/write-article/article.adoc
@@ -15,6 +15,8 @@ include::{includesdir}/docheader.adoc[]
 // Generated horizontal tag list; website only.
 ifeval::["{type}" != "readme"]
 include::{docfile}/../generated/{docname}-tags.adoc[opts=optional]
+// Generated translation provenance; empty unless the article is a translation.
+include::{docfile}/../generated/{docname}-translation.adoc[opts=optional]
 endif::[]
 
 [.highlight.info]

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -113,10 +113,10 @@ class ProfileCommentsTest < Minitest::Test
     # by the profile generator
     template = Pathname.new(__dir__).join('../templates/write-article/article.adoc').read
     generator = Pathname.new(__dir__).join('../scripts/validate-profile-metamodel.rb').read
-    generated_suffixes = generator.scan(/#\{article_slug\(article\)\}-(navigation|tags|comments)\.adoc/).flatten.uniq
+    generated_suffixes = generator.scan(/#\{article_slug\(article\)\}-(navigation|tags|comments|translation)\.adoc/).flatten.uniq
 
     # Then: new articles include every generated fragment family
-    assert_equal %w[comments navigation tags], generated_suffixes.sort
+    assert_equal %w[comments navigation tags translation], generated_suffixes.sort
     generated_suffixes.each do |suffix|
       assert_includes template, "include::{docfile}/../generated/{docname}-#{suffix}.adoc[opts=optional]"
     end

--- a/test/profile_translation_test.rb
+++ b/test/profile_translation_test.rb
@@ -1,0 +1,156 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for translation provenance.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in
+# features/article-translation-provenance.feature, with Given/When/Then comment
+# anchors separating Arrange, Act, and Assert. Each test builds an isolated
+# temporary profile tree so the real repository is never touched.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfileTranslationTest < Minitest::Test
+  # Builds an original and, optionally, a translation of it. The translation's
+  # recorded digest is computed from the original's source unless the test asks
+  # for a stale one.
+  def with_translation(original_body: "= Original\nText.\n", digest: :current, divergence: nil, translated: true)
+    Dir.mktmpdir('profile-translation-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'includes/i18n').mkpath
+      (root + 'includes/i18n/ui-de.adoc').write(":ui_nav_home: Home\n")
+      (root + 'includes/i18n/ui-en.adoc').write(":ui_nav_home: Home\n")
+
+      (root + 'site/articles').mkpath
+      (root + 'site/articles/original.adoc').write(original_body)
+      (root + 'site/articles/original.profile.yaml').write(metadata('ART-001-original', 'de', 'site/articles/original.adoc'))
+
+      if translated
+        recorded = digest == :current ? Digest::SHA256.hexdigest(original_body) : digest
+        (root + 'site/en/articles').mkpath
+        (root + 'site/en/articles/original.adoc').write("= Original\nText.\n")
+        extra = { 'translation_of' => 'ART-001-original' }
+        extra['translation_source_digest'] = recorded unless recorded.nil?
+        extra['translation_divergence'] = divergence if divergence
+        (root + 'site/en/articles/original.profile.yaml').write(
+          metadata('ART-001-original-en', 'en', 'site/en/articles/original.adoc', extra)
+        )
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield(validator, artifacts, root)
+    end
+  end
+
+  def metadata(id, language, source, extra = {})
+    {
+      'id' => id, 'type' => 'Article', 'title' => id, 'status' => 'published',
+      'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => language, 'source' => source
+    }.merge(extra).to_yaml
+  end
+
+  def note(root, relative)
+    path = root + relative
+    path.exist? ? path.read : ''
+  end
+
+  def test_original_article_shows_no_provenance_note
+    # Given: an article that was not translated from another article
+    with_translation(translated: false) do |validator, artifacts, root|
+      # When: the translation notes are generated
+      validator.generate_translation_notes(artifacts)
+
+      # Then: its translation note file is empty
+      assert_empty note(root, 'site/articles/generated/original-translation.adoc')
+    end
+  end
+
+  def test_translation_names_the_article_it_came_from
+    # Given: a translation whose recorded digest matches its original
+    with_translation do |validator, artifacts, root|
+      # When: the translation notes are generated
+      validator.generate_translation_notes(artifacts)
+
+      # Then: its note states that the article is a translation and links to the original
+      generated = note(root, 'site/en/articles/generated/original-translation.adoc')
+      assert_includes generated, '{ui_translation_of}'
+      assert_match(%r{<a href="[^"]*original\.html">}, generated)
+      refute_includes generated, '{ui_translation_outdated}'
+    end
+  end
+
+  def test_changed_original_marks_its_translations_as_outdated
+    # Given: a translation whose original has changed since the translation was written
+    with_translation(digest: 'b' * 64) do |validator, artifacts, root|
+      # When: the translation notes are generated
+      validator.generate_translation_notes(artifacts)
+      validator.report_translation_states(artifacts)
+
+      # Then: its note additionally states that the original has changed,
+      # and the outdated translation is reported to the author
+      generated = note(root, 'site/en/articles/generated/original-translation.adoc')
+      assert_includes generated, '{ui_translation_of}'
+      assert_includes generated, '{ui_translation_outdated}'
+      assert validator.warnings.any? { |warning| warning.include?('is outdated') },
+             "expected an outdated warning, got: #{validator.warnings.inspect}"
+    end
+  end
+
+  def test_outdated_translation_stays_publishable
+    # Given: a translation whose original has changed since the translation was written
+    with_translation(digest: 'b' * 64) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated (done by the helper)
+      # Then: validation reports no error
+      assert_empty validator.errors
+    end
+  end
+
+  def test_re_accepting_the_original_clears_the_outdated_note
+    # Given: a translation whose original has changed since the translation was written
+    with_translation(digest: 'b' * 64) do |validator, artifacts, root|
+      # When: the author re-accepts the current original for that translation
+      validator.accept_translation(artifacts, 'ART-001-original-en')
+
+      # Then: its note no longer states that the original has changed
+      revalidated = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      reloaded = revalidated.validate
+      revalidated.generate_translation_notes(reloaded)
+
+      generated = note(root, 'site/en/articles/generated/original-translation.adoc')
+      assert_includes generated, '{ui_translation_of}'
+      refute_includes generated, '{ui_translation_outdated}'
+    end
+  end
+
+  def test_deliberate_divergence_is_shown_even_when_the_translation_is_in_sync
+    # Given: a translation that declares a deliberate difference from its original
+    with_translation(divergence: 'shortened for the web') do |validator, artifacts, root|
+      # When: the translation notes are generated
+      validator.generate_translation_notes(artifacts)
+
+      # Then: its note states that the content differs from the original
+      generated = note(root, 'site/en/articles/generated/original-translation.adoc')
+      assert_includes generated, '{ui_translation_divergent}'
+      refute_includes generated, '{ui_translation_outdated}'
+    end
+  end
+
+  def test_outdated_and_deliberately_different_are_shown_together
+    # Given: a translation that declares a deliberate difference and whose original has changed
+    with_translation(digest: 'b' * 64, divergence: 'shortened for the web') do |validator, artifacts, root|
+      # When: the translation notes are generated
+      validator.generate_translation_notes(artifacts)
+
+      # Then: its note states both that the original has changed and that the content differs
+      generated = note(root, 'site/en/articles/generated/original-translation.adoc')
+      assert_includes generated, '{ui_translation_outdated}'
+      assert_includes generated, '{ui_translation_divergent}'
+    end
+  end
+end


### PR DESCRIPTION
Closes #54. Seventh slice of #47.

Tells a reader that the article they are on is a translation, which text it came from, and whether it still matches that text.

## Specified first this time

`features/article-translation-provenance.feature` was written **before** the implementation and carries all seven scenarios, bridged to `test/profile_translation_test.rb` through the scenario-to-test naming convention with `Given`/`When`/`Then` anchors.

That was the process gap you spotted on #53. It is fixed going forward here, and the retroactive scenarios for #49–#53 are tracked in #65.

## Behaviour

| State | Reader sees |
|---|---|
| Original | nothing |
| Translation, in sync | *"Das ist eine Übersetzung vom Originalartikel …"* linking to the original |
| Translation, outdated | plus *"Der Originalartikel wurde seit dieser Übersetzung geändert."* |
| Translation, divergent | plus *"Dieser Text weicht inhaltlich bewusst vom Original ab."* |
| Both | both notes, since staleness and intent are independent |

An outdated translation **stays publishable** — never a build failure — and is reported to the author as a warning instead.

## The author override

Freshness is derived by comparing a digest of the original's **full source**, recorded at translation time, against the original as it is now. That derived state is a default, not a verdict:

```sh
ruby scripts/validate-profile-metamodel.rb --accept-translation ART-003-doc-as-code-en
```

records the current original's digest without touching the translation — the intended answer to a typo fix or another cosmetic change that needed no work on the translated text. Covered by its own scenario.

A translation without a recorded digest is not silently treated as fresh; it is reported as untracked.

## Changes

* `validate-profile-metamodel.rb` — `generate_translation_notes`, `translation_state`, `source_digest`, `report_translation_states`, `accept_translation`, plus the `--accept-translation` mode.
* `ui-de.adoc` / `ui-en.adoc` — 3 keys; the note resolves its wording through the page it lands on, like the rest of the article chrome.
* The three articles and `templates/write-article/article.adoc` include the new generated fragment right after the tag list, so the note appears at the top of the article.
* `build.gradle` — `testProfileTranslation`.

## Verification

**German output byte-identical**: the note file is empty for originals, and all current articles are originals.

```
Only in build/site: en
```

| Check | Result |
|---|---|
| `profile_translation` | 7 runs, 27 assertions, 0 failures |
| `profile_language` | 33 runs, 97 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 12 runs, 56 assertions, 0 failures |
| `profile_comments` | 7 runs, 60 assertions, 0 failures |
| `site_metadata_injector` | 8 runs, 21 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 0 errors |

`test_article_template_includes_every_generated_article_fragment` now expects four fragment families instead of three, so a future one cannot be added without also reaching the template.

## Open for review

The note is rendered as `<aside class="translation-note">` and currently has no styling in `style.css`. It will inherit default paragraph styling until someone decides how prominent it should be — worth a look when the first real translation lands in #57.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
