### PR TITLE
issue_55: Make language variants discoverable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -435,6 +435,19 @@ tasks.register('testProfileLanguage') {
     }
 }
 
+tasks.register('testProfileLanguageAlternates') {
+    description = 'Runs the language switcher and alternate-link behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_language_alternates_test.rb')
+    inputs.files('features/language-alternates.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_language_alternates_test.rb'
+        }
+    }
+}
+
 tasks.register('testProfileTranslation') {
     description = 'Runs the translation provenance behaviour tests.'
     group = 'verification'
@@ -581,7 +594,8 @@ tasks.named('buildSite') {
         def command = [
                 'ruby',
                 'scripts/inject-site-metadata.rb',
-                '--site-dir', layout.buildDirectory.dir('site').get().asFile
+                '--site-dir', layout.buildDirectory.dir('site').get().asFile,
+                '--alternates', layout.buildDirectory.file('site-metadata/language-alternates.json').get().asFile
         ]
         if (env('SITE_BASE_URL')) {
             command += ['--base-url', env('SITE_BASE_URL')]
@@ -642,7 +656,8 @@ tasks.register("buildArticleListPages${suffix}", org.asciidoctor.gradle.jvm.Asci
         def command = [
                 'ruby',
                 'scripts/inject-site-metadata.rb',
-                '--site-dir', layout.buildDirectory.dir('site').get().asFile
+                '--site-dir', layout.buildDirectory.dir('site').get().asFile,
+                '--alternates', layout.buildDirectory.file('site-metadata/language-alternates.json').get().asFile
         ]
         if (env('SITE_BASE_URL')) {
             command += ['--base-url', env('SITE_BASE_URL')]

--- a/features/language-alternates.feature
+++ b/features/language-alternates.feature
@@ -1,0 +1,49 @@
+# Living documentation for making the language variants of a page discoverable:
+# in the page chrome for readers, and in the HTML head for search engines.
+#
+# Bridged to: test/profile_language_alternates_test.rb and
+# test/site_metadata_injector_test.rb (classic Minitest, no native BDD runner in
+# this repository). Each scenario maps to at least one automated test method
+# named after the sanitized scenario title, with Given/When/Then comment anchors
+# inside it. Traceability is a reviewer-verifiable convention, not a
+# build-enforced link.
+#
+# A variant only counts when the page really exists in that language. A page
+# that merely falls back to the default language is not an alternate: offering
+# it would promise a translation that was never written.
+
+Feature: Language alternates
+  As a reader who speaks another language, and as a search engine
+  I want to find the language variants of a page
+  So that I land on the right language and the variants are not treated as duplicates
+
+  Scenario: Page with a translation offers a language switcher
+    Given a page that exists in the default language and in one other language
+    When the language switchers are generated
+    Then each variant offers a link to the other and marks its own language as current
+
+  Scenario: Page without a translation offers no language switcher
+    Given a page that exists in the default language only
+    When the language switchers are generated
+    Then its language switcher file is empty
+
+  Scenario: Fallback pages are not offered as translations
+    Given a page that exists in the default language only
+    And another page in that same site that has been translated
+    When the language switchers are generated
+    Then the untranslated page still offers no language switcher
+
+  Scenario: Translation group is published as alternate links
+    Given a rendered site whose page exists in two languages
+    When the site metadata is injected
+    Then each variant links to both variants as alternates and names the default language as x-default
+
+  Scenario: Page without variants carries no alternate links
+    Given a rendered site whose page exists in one language only
+    When the site metadata is injected
+    Then that page carries no alternate links
+
+  Scenario: Alternate links leave canonical links untouched
+    Given a rendered site whose page exists in two languages
+    When the site metadata is injected
+    Then each variant keeps the canonical URL of its own output path

--- a/scripts/inject-site-metadata.rb
+++ b/scripts/inject-site-metadata.rb
@@ -1,15 +1,46 @@
 # frozen_string_literal: true
 
+require 'json'
 require 'optparse'
 require 'pathname'
 require 'uri'
 
 class SiteMetadataInjector
-  attr_reader :site_dir, :base_url
+  attr_reader :site_dir, :base_url, :alternates, :default_language
 
-  def initialize(site_dir:, base_url:)
+  # The rendered site carries no metadata, so the translation groups are handed
+  # in as output paths: a map of language to path, produced by the profile
+  # generator, which is the only place that knows which pages are variants of
+  # one another. A page that merely falls back to another language is not in it.
+  def initialize(site_dir:, base_url:, alternates: nil)
     @site_dir = Pathname.new(site_dir).expand_path
     @base_url = normalize_base_url(base_url)
+    @default_language = alternates && alternates['default_language']
+    @alternates = index_alternates(alternates)
+  end
+
+  def index_alternates(alternates)
+    return {} if alternates.nil?
+
+    Array(alternates['groups']).each_with_object({}) do |group, index|
+      group.each_value { |path| index[path] = group }
+    end
+  end
+
+  # Alternate links for one output path, or an empty list when the page has no
+  # variants. Every variant of a group links to all variants including itself,
+  # which is what search engines expect, plus x-default for the default language.
+  def alternate_links(relative_path)
+    group = alternates[relative_path]
+    return [] if group.nil?
+
+    links = group.map do |language, path|
+      %(<link rel="alternate" hreflang="#{language}" href="#{canonical_url(site_dir.join(path))}">)
+    end
+
+    fallback = group[default_language]
+    links << %(<link rel="alternate" hreflang="x-default" href="#{canonical_url(site_dir.join(fallback))}">) if fallback
+    links
   end
 
   def inject
@@ -66,6 +97,13 @@ class SiteMetadataInjector
               else
                 content.sub('</head>') { "#{canonical}\n</head>" }
               end
+
+    # Injection is idempotent: previously written alternates are replaced rather
+    # than appended, because the listing pages re-run this step.
+    updated = updated.gsub(%r{^<link\b[^>]*\brel="alternate"[^>]*>\n}, '')
+    links = alternate_links(html_path.relative_path_from(site_dir).to_s.tr('\\', '/'))
+    updated = updated.sub('</head>') { "#{links.join("\n")}\n</head>" } unless links.empty?
+
     html_path.write(updated, encoding: 'UTF-8')
   end
 end
@@ -76,6 +114,7 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--site-dir PATH') { |value| options[:site_dir] = value }
     parser.on('--base-url URL') { |value| options[:base_url] = value }
     parser.on('--required') { options[:required] = true }
+    parser.on('--alternates PATH') { |value| options[:alternates] = value }
   end.parse!
 
   if options[:base_url].nil? || options[:base_url].strip.empty?
@@ -85,5 +124,13 @@ if $PROGRAM_NAME == __FILE__
   end
 
   abort '--site-dir is required' unless options[:site_dir]
-  SiteMetadataInjector.new(site_dir: options[:site_dir], base_url: options[:base_url]).inject
+
+  alternates = nil
+  if options[:alternates] && File.file?(options[:alternates])
+    alternates = JSON.parse(File.read(options[:alternates], encoding: 'UTF-8'))
+  end
+
+  SiteMetadataInjector.new(
+    site_dir: options[:site_dir], base_url: options[:base_url], alternates: alternates
+  ).inject
 end

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -214,6 +214,106 @@ class ProfileArtifactValidator
     written
   end
 
+  # Writes one language switcher per page next to it, empty unless the page
+  # really exists in more than one language. A page that merely falls back to the
+  # default language is not offered as a variant: that would promise a
+  # translation nobody wrote.
+  def generate_language_switchers(artifacts)
+    clean_generated_language_switchers
+
+    groups = translation_groups(artifacts)
+
+    groups.values.select { |variants| variants.length > 1 }.flat_map do |variants|
+      variants.map do |variant|
+        dir = article_source_path(variant).dirname.join('generated')
+        FileUtils.mkdir_p(dir)
+        path = dir.join("#{article_slug(variant)}-langswitch.adoc")
+        path.write(render_language_switcher(variant, variants), encoding: 'UTF-8')
+        path
+      end
+    end
+  end
+
+  # Artifacts that are translations of one another, keyed by their group, and
+  # only those that are rendered as pages.
+  def translation_groups(artifacts)
+    artifacts.select { |artifact| page_artifact?(artifact) }
+             .group_by { |artifact| translation_group_key(artifact) }
+  end
+
+  def page_artifact?(artifact)
+    !artifact_output_path(artifact).nil?
+  end
+
+  def render_language_switcher(current, variants)
+    ordered = variants.sort_by { |variant| artifact_language(variant) }
+    items = ordered.map do |variant|
+      language = artifact_language(variant)
+      if variant.equal?(current)
+        "    <li><span class=\"language-switch-current\" lang=\"#{language}\">{ui_language_name_#{language}}</span></li>"
+      else
+        href = h(article_link_href(current, variant))
+        "    <li><a href=\"#{href}\" lang=\"#{language}\" hreflang=\"#{language}\">{ui_language_name_#{language}}</a></li>"
+      end
+    end
+
+    # Raw HTML without block delimiters: this file is included from inside the
+    # menu's passthrough block, which already applies attribute substitution.
+    # Splitting that block to include it as a block of its own would change the
+    # whitespace of every rendered page.
+    ['<nav class="language-switch" aria-label="{ui_language_switch_label}">',
+     '  <ul>',
+     *items,
+     '  </ul>',
+     '</nav>',
+     ''].join("\n")
+  end
+
+  def clean_generated_language_switchers
+    Dir.glob(profile_dir.join('**', 'generated', '*-langswitch.adoc').to_s).each do |path|
+      File.delete(path)
+    end
+  end
+
+  # The rendered site has no metadata, so the translation groups are handed to
+  # the metadata injector as output paths it can match against the files it walks.
+  def generate_language_alternates(artifacts, output:)
+    groups = translation_groups(artifacts).values.select { |variants| variants.length > 1 }
+
+    entries = groups.map do |variants|
+      variants.sort_by { |variant| artifact_language(variant) }.to_h do |variant|
+        [artifact_language(variant), artifact_output_path(variant)]
+      end
+    end
+
+    output_path = root.join(output)
+    FileUtils.mkdir_p(output_path.dirname)
+    output_path.write(
+      "#{JSON.pretty_generate({ 'schema_version' => 1, 'default_language' => DEFAULT_LANGUAGE, 'groups' => entries })}\n",
+      encoding: 'UTF-8'
+    )
+    output_path
+  end
+
+  # Output path of a page artifact relative to the site root, or nil when the
+  # artifact is not rendered as a site page. Derived from the resolved source
+  # path rather than the raw metadata string, so it follows profile_dir like the
+  # rest of the generator instead of assuming a fixed repository layout.
+  def artifact_output_path(artifact)
+    path = article_source_path(artifact)
+    return nil unless path.to_s.end_with?('.adoc')
+
+    relative = path.relative_path_from(profile_dir).to_s
+    return nil if relative.start_with?('..')
+
+    source_root = SITE_SOURCE_ROOTS.find { |name| relative.start_with?("#{name}/") }
+    return nil if source_root.nil?
+
+    relative.delete_prefix("#{source_root}/").sub(/\.adoc\z/, '.html')
+  rescue ArgumentError
+    nil
+  end
+
   # Writes one provenance note per article next to it, empty for originals.
   # A translation always says what it came from; an outdated or deliberately
   # divergent one additionally says how it relates to that text. Both notes can
@@ -1536,7 +1636,8 @@ if $PROGRAM_NAME == __FILE__
     generate: false,
     output: nil,
     article_comment_allowlist: nil,
-    accept_translation: nil
+    accept_translation: nil,
+    language_alternates: nil
   }
   OptionParser.new do |parser|
     parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
@@ -1545,6 +1646,7 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--output PATH') { |value| options[:output] = value }
     parser.on('--article-comment-allowlist PATH') { |value| options[:article_comment_allowlist] = value }
     parser.on('--accept-translation ID') { |value| options[:accept_translation] = value }
+    parser.on('--language-alternates PATH') { |value| options[:language_alternates] = value }
   end.parse!
 
   root = options[:root]
@@ -1581,6 +1683,13 @@ if $PROGRAM_NAME == __FILE__
     puts "Generated #{list_paths.length} article list file(s)."
     note_paths = validator.generate_translation_notes(artifacts)
     puts "Generated #{note_paths.length} translation note(s)."
+    switcher_paths = validator.generate_language_switchers(artifacts)
+    puts "Generated #{switcher_paths.length} language switcher(s)."
+    alternates_path = validator.generate_language_alternates(
+      artifacts,
+      output: options[:language_alternates] || 'build/site-metadata/language-alternates.json'
+    )
+    puts "Generated language alternates: #{alternates_path.relative_path_from(root)}"
     registry_paths = validator.generate_link_registries(artifacts)
     puts "Generated #{registry_paths.length} link registry file(s)."
     validator.report_translation_states(artifacts)

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -30,3 +30,6 @@
 :ui_translation_of: Das ist eine Übersetzung vom Originalartikel
 :ui_translation_outdated: Der Originalartikel wurde seit dieser Übersetzung geändert.
 :ui_translation_divergent: Dieser Text weicht inhaltlich bewusst vom Original ab.
+:ui_language_switch_label: Sprache wählen
+:ui_language_name_de: Deutsch
+:ui_language_name_en: English

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -32,4 +32,4 @@
 :ui_translation_divergent: Dieser Text weicht inhaltlich bewusst vom Original ab.
 :ui_language_switch_label: Sprache wählen
 :ui_language_name_de: Deutsch
-:ui_language_name_en: English
+:ui_language_name_en: Englisch

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -31,5 +31,5 @@
 :ui_translation_outdated: The original article has changed since this translation was written.
 :ui_translation_divergent: This text deliberately differs in content from the original.
 :ui_language_switch_label: Choose language
-:ui_language_name_de: Deutsch
+:ui_language_name_de: German
 :ui_language_name_en: English

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -30,3 +30,6 @@
 :ui_translation_of: This is a translation of the original article
 :ui_translation_outdated: The original article has changed since this translation was written.
 :ui_translation_divergent: This text deliberately differs in content from the original.
+:ui_language_switch_label: Choose language
+:ui_language_name_de: Deutsch
+:ui_language_name_en: English

--- a/src-content/profile/includes/menue.adoc
+++ b/src-content/profile/includes/menue.adoc
@@ -37,6 +37,7 @@ endif::[]
 </div>
 <div class="nav-overlay"></div>
 </nav>
+include::{docfile}/../generated/{docname}-langswitch.adoc[opts=optional]
 
 <script type="text/javascript" src="{basedir}/stylesheet/navigation.js"></script>
 ++++

--- a/test/profile_language_alternates_test.rb
+++ b/test/profile_language_alternates_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for the language switcher.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in features/language-alternates.feature,
+# with Given/When/Then comment anchors separating Arrange, Act, and Assert. The
+# alternate-link scenarios of the same feature are bridged in
+# test/site_metadata_injector_test.rb, because they belong to the injector.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfileLanguageAlternatesTest < Minitest::Test
+  def with_pages(pages)
+    Dir.mktmpdir('profile-alternates-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'includes/i18n').mkpath
+      (root + 'includes/i18n/ui-de.adoc').write(":ui_nav_home: Home\n")
+      (root + 'includes/i18n/ui-en.adoc').write(":ui_nav_home: Home\n")
+
+      pages.each do |page|
+        rel_dir = page.fetch(:dir)
+        slug = page.fetch(:slug)
+        (root + rel_dir).mkpath
+        source = "#{rel_dir}/#{slug}.adoc"
+        (root + source).write("= #{slug}\n")
+        metadata = {
+          'id' => page.fetch(:id), 'type' => 'ProfilePage', 'title' => slug, 'status' => 'published',
+          'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => page.fetch(:language),
+          'source' => source
+        }
+        metadata['translation_of'] = page[:translation_of] if page[:translation_of]
+        (root + "#{rel_dir}/#{slug}.profile.yaml").write(metadata.to_yaml)
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield(validator, artifacts, root)
+    end
+  end
+
+  def switcher(root, relative)
+    path = root + relative
+    path.exist? ? path.read : ''
+  end
+
+  def test_page_with_a_translation_offers_a_language_switcher
+    # Given: a page that exists in the default language and in one other language
+    with_pages([
+                 { id: 'PAGE-001-index', slug: 'index', dir: 'site', language: 'de' },
+                 { id: 'PAGE-001-index-en', slug: 'index', dir: 'site/en', language: 'en',
+                   translation_of: 'PAGE-001-index' }
+               ]) do |validator, artifacts, root|
+      # When: the language switchers are generated
+      validator.generate_language_switchers(artifacts)
+
+      # Then: each variant links to the other and marks its own language as current
+      german = switcher(root, 'site/generated/index-langswitch.adoc')
+      english = switcher(root, 'site/en/generated/index-langswitch.adoc')
+
+      assert_includes german, '<span class="language-switch-current" lang="de">'
+      assert_match(%r{<a href="[^"]*en/index\.html" lang="en"}, german)
+      assert_includes english, '<span class="language-switch-current" lang="en">'
+      assert_match(%r{<a href="[^"]*index\.html" lang="de"}, english)
+    end
+  end
+
+  def test_page_without_a_translation_offers_no_language_switcher
+    # Given: a page that exists in the default language only
+    with_pages([{ id: 'PAGE-001-index', slug: 'index', dir: 'site', language: 'de' }]) do |validator, artifacts, root|
+      # When: the language switchers are generated
+      validator.generate_language_switchers(artifacts)
+
+      # Then: its language switcher file is empty
+      assert_empty switcher(root, 'site/generated/index-langswitch.adoc')
+    end
+  end
+
+  def test_fallback_pages_are_not_offered_as_translations
+    # Given: a page that exists in the default language only
+    # And: another page in that same site that has been translated
+    with_pages([
+                 { id: 'PAGE-002-legal', slug: 'legal', dir: 'site', language: 'de' },
+                 { id: 'PAGE-001-index', slug: 'index', dir: 'site', language: 'de' },
+                 { id: 'PAGE-001-index-en', slug: 'index', dir: 'site/en', language: 'en',
+                   translation_of: 'PAGE-001-index' }
+               ]) do |validator, artifacts, root|
+      # When: the language switchers are generated
+      validator.generate_language_switchers(artifacts)
+
+      # Then: the untranslated page still offers no language switcher
+      assert_empty switcher(root, 'site/generated/legal-langswitch.adoc')
+      refute_empty switcher(root, 'site/generated/index-langswitch.adoc')
+    end
+  end
+end

--- a/test/site_metadata_injector_test.rb
+++ b/test/site_metadata_injector_test.rb
@@ -71,6 +71,68 @@ class SiteMetadataInjectorTest < Minitest::Test
     end
   end
 
+  # Scenarios from features/language-alternates.feature that belong to the
+  # injector. The rendered site carries no metadata, so the translation groups
+  # are handed in as output paths.
+  ALTERNATES = {
+    'schema_version' => 1,
+    'default_language' => 'de',
+    'groups' => [{ 'de' => 'index.html', 'en' => 'en/index.html' }]
+  }.freeze
+
+  def alternate_hrefs(path)
+    path.read.scan(/<link rel="alternate" hreflang="([^"]+)" href="([^"]+)">/)
+  end
+
+  def test_translation_group_is_published_as_alternate_links
+    # Given: a rendered site whose page exists in two languages
+    with_site(%w[index.html en/index.html]) do |site|
+      injector = SiteMetadataInjector.new(site_dir: site, base_url: 'https://example.test',
+                                          alternates: ALTERNATES)
+
+      # When: the site metadata is injected
+      injector.inject
+
+      # Then: each variant links to both variants and names the default language as x-default
+      expected = [%w[de https://example.test/], %w[en https://example.test/en/],
+                  ['x-default', 'https://example.test/']]
+      assert_equal expected, alternate_hrefs(site.join('index.html'))
+      assert_equal expected, alternate_hrefs(site.join('en/index.html'))
+    end
+  end
+
+  def test_page_without_variants_carries_no_alternate_links
+    # Given: a rendered site whose page exists in one language only
+    with_site(%w[index.html legal.html en/index.html]) do |site|
+      injector = SiteMetadataInjector.new(site_dir: site, base_url: 'https://example.test',
+                                          alternates: ALTERNATES)
+
+      # When: the site metadata is injected
+      injector.inject
+
+      # Then: that page carries no alternate links
+      assert_empty alternate_hrefs(site.join('legal.html'))
+    end
+  end
+
+  def test_alternate_links_leave_canonical_links_untouched
+    # Given: a rendered site whose page exists in two languages
+    with_site(%w[index.html en/index.html]) do |site|
+      injector = SiteMetadataInjector.new(site_dir: site, base_url: 'https://example.test',
+                                          alternates: ALTERNATES)
+
+      # When: the site metadata is injected, twice, as the listing build does
+      injector.inject
+      injector.inject
+
+      # Then: each variant keeps the canonical URL of its own output path,
+      # and the alternates are replaced rather than appended
+      assert_equal 'https://example.test/', canonical_href(site.join('index.html'))
+      assert_equal 'https://example.test/en/', canonical_href(site.join('en/index.html'))
+      assert_equal 3, alternate_hrefs(site.join('index.html')).length
+    end
+  end
+
   def test_special_characters_in_output_paths_are_percent_encoded
     # Given: a generated public page whose output path contains spaces and non-ASCII characters
     with_site(['articles/Über uns & mehr.html']) do |site|


### PR DESCRIPTION
Closes #55. Eighth slice of #47.

Makes the language variants of a page discoverable — in the chrome for readers, in the HTML head for search engines.

Specified first: `features/language-alternates.feature`, bridged to `test/profile_language_alternates_test.rb` (switcher scenarios) and `test/site_metadata_injector_test.rb` (alternate-link scenarios).

## What a reader sees

On the German index:

```html
<nav class="language-switch" aria-label="Sprache wählen">
  <ul>
    <li><span class="language-switch-current" lang="de">Deutsch</span></li>
    <li><a href="en/index.html" lang="en" hreflang="en">English</a></li>
  </ul>
</nav>
```

and in the head of both variants:

```html
<link rel="alternate" hreflang="de" href="https://dieterbaier.eu/">
<link rel="alternate" hreflang="en" href="https://dieterbaier.eu/en/">
<link rel="alternate" hreflang="x-default" href="https://dieterbaier.eu/">
```

**A fallback is not an alternate.** A page that merely falls back to German is not offered as a translation — that would promise a text nobody wrote. Untranslated pages carry neither a switcher nor alternate links, which is why only `index.html` changes.

## How the map reaches the injector

#55 asked for this to be decided and documented. The injector walks the rendered output, which carries no metadata, so the translation groups are handed to it as generated JSON:

```json
{ "schema_version": 1, "default_language": "de",
  "groups": [{ "de": "index.html", "en": "en/index.html" }] }
```

Same shape and same delivery path as the existing comment allowlist. Injection is idempotent — previously written alternates are replaced, not appended — because the listing build runs the injector a second time. Covered by a scenario that injects twice.

## One implementation detail worth the comment it got

The switcher is included from **inside** the menu's existing passthrough block. My first attempt split that block in two to include the switcher as a block of its own, and the rendered whitespace of *every* page changed. Preprocessor directives work inside a passthrough, so the switcher file now emits raw HTML without delimiters and the block stays whole.

## Verification

German output changes on exactly one page — `index.html`, the only German page that has a translation:

```
Only in build/site: en
index.html
```

```diff
+ <nav class="language-switch" aria-label="Sprache wählen">
+   <ul>
+     <li><span class="language-switch-current" lang="de">Deutsch</span></li>
+     <li><a href="en/index.html" lang="en" hreflang="en">English</a></li>
+   </ul>
+ </nav>
```

| Check | Result |
|---|---|
| `profile_language_alternates` | 3 runs, 14 assertions, 0 failures |
| `site_metadata_injector` | 11 runs, 28 assertions, 0 failures |
| `profile_language` | 33 runs, 97 assertions, 0 failures |
| `profile_translation` | 7 runs, 27 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 12 runs, 56 assertions, 0 failures |
| `profile_comments` | 7 runs, 60 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 0 errors |

## A bug this slice surfaced and fixed

`artifact_output_path` and `page_artifact?` first hard-coded `src-content/profile/` while the rest of the generator derives paths from `profile_dir`. The tests caught it immediately — the switcher silently produced nothing in an isolated tree. Both now work off the resolved source path relative to `profile_dir`, consistent with `site_pages`.

## Open, as in #54

`.language-switch` has no styling in `style.css` yet. It renders as a plain list until you decide where it belongs — worth settling together with the translation note when #57 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
