### PR TITLE
issue_56: Bring the CV into the language model

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -435,6 +435,19 @@ tasks.register('testProfileLanguage') {
     }
 }
 
+tasks.register('testProfileCvLanguage') {
+    description = 'Runs the multilingual CV behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_cv_language_test.rb')
+    inputs.files('features/multilingual-cv.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_cv_language_test.rb'
+        }
+    }
+}
+
 tasks.register('testProfileLanguageAlternates') {
     description = 'Runs the language switcher and alternate-link behaviour tests.'
     group = 'verification'
@@ -576,6 +589,15 @@ asciidoctorBase('buildCVPersonal','','src-content/profile/cv', 'build/cv', ['cv.
 ])
 asciidoctorBase('buildCVSite','','src-content/profile/cv', 'build/site', [],true) // HTML
 asciidoctorBase('buildCVDownload','buildCVSite','src-content/profile/cv', 'build/site', ['cv.adoc'],false, 'pdf') // PDF download
+// The HTML task above already renders every language, because it filters no
+// sources and the plugin preserves the relative path. Only the downloadable PDF
+// is selected per file, so each additional CV language needs its own task. The
+// check uses the committed source tree, so it also holds on a clean checkout.
+['en'].findAll { file("src-content/profile/cv/${it}/cv.adoc").isFile() }.each { language ->
+    def taskName = "buildCVDownload${language.capitalize()}"
+    asciidoctorBase(taskName, 'buildCVSite', 'src-content/profile/cv', 'build/site', ["${language}/cv.adoc"], false, 'pdf')
+    tasks.named('buildSite') { dependsOn tasks.named(taskName) }
+}
 // Website
 asciidoctorBase('buildSite','buildCVDownload','src-content/profile/site', 'build/site', [],false, "html5",[
                                                                         'site-address-name': env('SITE_ADDRESS_NAME') ?: '.',

--- a/features/multilingual-cv.feature
+++ b/features/multilingual-cv.feature
@@ -1,0 +1,37 @@
+# Living documentation for the CV as a multilingual artifact: its shared chrome
+# follows the reader's language, and the downloadable PDF belongs to the language
+# variant it was rendered from.
+#
+# Bridged to: test/profile_cv_language_test.rb (classic Minitest, no native BDD
+# runner in this repository). Each scenario maps to at least one automated test
+# method named after the sanitized scenario title, with Given/When/Then comment
+# anchors inside it.
+#
+# The CV pulls in more content fragments than any other page, and fragments do
+# not fall back. A CV language variant is therefore publishable only once every
+# fragment it includes is translated, which is authoring work rather than
+# generator work.
+
+Feature: Multilingual CV
+  As someone handing my CV to an international employer
+  I want the CV in the reader's language, with its own PDF
+  So that I can pass on one coherent document instead of a mixed-language one
+
+  Scenario: CV download link points at the PDF of its own language variant
+    Given a CV that exists in the default language and in one other language
+    When the link registries are generated
+    Then each language resolves the CV download to the PDF beside its own CV page
+
+  Scenario: CV download link falls back with the default language marked
+    Given a CV that exists in the default language only
+    When the link registries are generated
+    Then the other language resolves the CV download to the default-language PDF
+
+  Scenario: CV chrome wording is resolved by the page it lands on
+    Given the shared CV chrome
+    Then it carries no wording of its own, only interface terms
+
+  Scenario: CV language variant is blocked until its fragments are translated
+    Given a CV language variant that includes a fragment available only in the default language
+    When the profile metadata is validated
+    Then validation reports that the fragment is missing in the variant's language

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -457,7 +457,14 @@ class ProfileArtifactValidator
     FileUtils.mkdir_p(registry_dir)
 
     pages = site_pages
-    languages = ([DEFAULT_LANGUAGE] + artifacts.map { |artifact| artifact_language(artifact) }).uniq
+    # Languages come from the page tree as well as from the metadata: the keys
+    # are derived from the file tree, so the language list has to be too, or a
+    # language whose pages carry no sidecar would get no registry at all.
+    page_languages = pages.keys.filter_map do |output|
+      prefix = output.split('/').first
+      prefix if LANGUAGES.include?(prefix) && prefix != DEFAULT_LANGUAGE
+    end
+    languages = ([DEFAULT_LANGUAGE] + page_languages + artifacts.map { |artifact| artifact_language(artifact) }).uniq
 
     languages.map do |language|
       entries = link_registry_entries(pages, language)
@@ -1003,7 +1010,7 @@ class ProfileArtifactValidator
     source_paths.each do |path|
       path.read(encoding: 'UTF-8').each_line.with_index do |line, index|
         line.scan(/\{(url_[a-z0-9_]+)\}/).flatten.each do |reference|
-          next if known.include?(reference.sub(/_(lang|marker)\z/, ''))
+          next if known.include?(reference.sub(/_(lang|marker|pdf)\z/, ''))
 
           errors << "#{relative(path)} line #{index + 1}: unknown page reference '{#{reference}}'"
         end
@@ -1072,12 +1079,19 @@ class ProfileArtifactValidator
       # unresolved. An empty value is written as a bare ':name:'.
       marker_line = marker.empty? ? ":#{key}_marker:" : ":#{key}_marker: #{marker}"
 
+      lines = ":#{key}: {basedir}/#{target}\n:#{key}_lang: #{resolved}\n#{marker_line}\n"
+
+      # The CV is the only page that also ships as a PDF, and the PDF is written
+      # next to its HTML. Giving it a registry entry keeps the download link in
+      # the shared CV chrome language-aware like every other reference.
+      lines += ":#{key}_pdf: {basedir}/#{target.sub(/\.html\z/, '.pdf')}\n" if output == 'cv.html'
+
       {
         key: key,
         output: output,
         resolved: resolved,
         fallback: resolved != language,
-        lines: ":#{key}: {basedir}/#{target}\n:#{key}_lang: #{resolved}\n#{marker_line}\n"
+        lines: lines
       }
     end
   end

--- a/src-content/profile/includes/author.adoc
+++ b/src-content/profile/includes/author.adoc
@@ -1,1 +1,1 @@
-Autor: xref:{basedir}/index.adoc[Dieter Baier]
+{ui_author_prefix} link:{url_index}[Dieter Baier{url_index_marker}]

--- a/src-content/profile/includes/cvappendix.adoc
+++ b/src-content/profile/includes/cvappendix.adoc
@@ -2,6 +2,6 @@ ifeval::["{backend}" == "html5"]
 ifeval::["{type}" == "cv"]
 [.new-section]
 endif::[]
-== Appendix
+== {ui_cv_appendix}
 include::./cvappendixnav.adoc[]
 endif::[]

--- a/src-content/profile/includes/cvappendixnav.adoc
+++ b/src-content/profile/includes/cvappendixnav.adoc
@@ -3,10 +3,10 @@
 <nav id="appendixnav" class="subnav noborder" data-active="{active}">
     <ul>
         <li>
-            <a data-nav="projects" href="{basedir}/projects.html">Projekte</a>
+            <a data-nav="projects" href="{url_projects}">{ui_cv_nav_projects}{url_projects_marker}</a>
         </li>
         <li>
-            <a data-nav="education" href="{basedir}/education.html">Weiterbildung</a>
+            <a data-nav="education" href="{url_education}">{ui_cv_nav_education}{url_education_marker}</a>
         </li>
     </ul>
 </nav>

--- a/src-content/profile/includes/cvheader.adoc
+++ b/src-content/profile/includes/cvheader.adoc
@@ -1,6 +1,7 @@
-:subtitle: Software Architekt
+include::./i18n/cascade.adoc[]
+:subtitle: {ui_cv_subtitle}
 ifeval::["{backend}" == "pdf"]
-:subtitle: {subtitle} - Curriculum Vitae
+:subtitle: {subtitle} - {ui_cv_document_kind}
 endif::[]
 = Dieter Baier
 {subtitle}
@@ -39,7 +40,7 @@ ifdef::buildsite[]
 <nav class="subnav noborder">
     <ul>
         <li>
-            <a class="fingerPointsTo" href="{basedir}/cv.pdf" target="_blank">Download CV</a>
+            <a class="fingerPointsTo" href="{url_cv_pdf}" target="_blank">{ui_cv_download}</a>
         </li>
     </ul>
 </nav>

--- a/src-content/profile/includes/docheader.adoc
+++ b/src-content/profile/includes/docheader.adoc
@@ -1,16 +1,7 @@
-ifeval::["{lang}" == ""]
-:lang: de
-endif::[]
-ifndef::lang[]
-:lang: de
-endif::[]
 // Interface terms, resolved as a cascade: the default language defines every
 // key, the page language overrides what it translates. Later assignments win in
 // AsciiDoc, so this needs no file-existence check, which AsciiDoc cannot express.
-include::./i18n/ui-de.adoc[]
-ifeval::["{lang}" != "de"]
-include::./i18n/ui-{lang}.adoc[opts=optional]
-endif::[]
+include::./i18n/cascade.adoc[]
 // Page references, generated per language: same-language page where one exists,
 // default language otherwise. Values are relative to {basedir}, so they work at
 // any page depth and in the local and PDF builds.

--- a/src-content/profile/includes/i18n/cascade.adoc
+++ b/src-content/profile/includes/i18n/cascade.adoc
@@ -1,0 +1,10 @@
+ifeval::["{lang}" == ""]
+:lang: de
+endif::[]
+ifndef::lang[]
+:lang: de
+endif::[]
+include::./ui-de.adoc[]
+ifeval::["{lang}" != "de"]
+include::./ui-{lang}.adoc[opts=optional]
+endif::[]

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -33,3 +33,10 @@
 :ui_language_switch_label: Sprache wählen
 :ui_language_name_de: Deutsch
 :ui_language_name_en: Englisch
+:ui_cv_subtitle: Software Architekt
+:ui_cv_document_kind: Curriculum Vitae
+:ui_cv_download: Download CV
+:ui_cv_appendix: Appendix
+:ui_cv_nav_projects: Projekte
+:ui_cv_nav_education: Weiterbildung
+:ui_author_prefix: Autor:

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -33,3 +33,10 @@
 :ui_language_switch_label: Choose language
 :ui_language_name_de: German
 :ui_language_name_en: English
+:ui_cv_subtitle: Software Architect
+:ui_cv_document_kind: Curriculum Vitae
+:ui_cv_download: Download CV
+:ui_cv_appendix: Appendix
+:ui_cv_nav_projects: Projects
+:ui_cv_nav_education: Professional development
+:ui_author_prefix: Author:

--- a/test/profile_cv_language_test.rb
+++ b/test/profile_cv_language_test.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for the multilingual CV.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in features/multilingual-cv.feature,
+# with Given/When/Then comment anchors separating Arrange, Act, and Assert.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfileCvLanguageTest < Minitest::Test
+  CHROME = %w[cvheader.adoc cvappendix.adoc cvappendixnav.adoc author.adoc].freeze
+
+  # Builds a tree with a German CV and, optionally, a language variant of it.
+  def with_cv(languages:, fragments: {})
+    Dir.mktmpdir('profile-cv-language-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'includes/i18n').mkpath
+      (root + 'includes/i18n/ui-de.adoc').write(":ui_nav_home: Home\n")
+      (root + 'includes/i18n/ui-en.adoc').write(":ui_nav_home: Home\n")
+
+      fragments.each do |relative, body|
+        path = root + "includes/i18n/#{relative}"
+        path.dirname.mkpath
+        path.write(body)
+      end
+
+      languages.each do |language, body|
+        rel_dir = language == 'de' ? 'cv' : "cv/#{language}"
+        (root + rel_dir).mkpath
+        (root + "#{rel_dir}/cv.adoc").write(body)
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield(validator, artifacts, root)
+    end
+  end
+
+  def registry(root, language)
+    path = root + "includes/generated/i18n/links-#{language}.adoc"
+    path.exist? ? path.read : ''
+  end
+
+  def test_cv_download_link_points_at_the_pdf_of_its_own_language_variant
+    # Given: a CV that exists in the default language and in one other language
+    with_cv(languages: { 'de' => "= CV\n", 'en' => "= CV\n" }) do |validator, artifacts, root|
+      # When: the link registries are generated
+      validator.generate_link_registries(artifacts)
+
+      # Then: each language resolves the CV download to the PDF beside its own CV page
+      assert_includes registry(root, 'de'), ":url_cv_pdf: {basedir}/cv.pdf\n"
+      assert_includes registry(root, 'en'), ":url_cv_pdf: {basedir}/en/cv.pdf\n"
+    end
+  end
+
+  def test_cv_download_link_falls_back_with_the_default_language_marked
+    # Given: a CV that exists in the default language only
+    with_cv(languages: { 'de' => "= CV\n" }) do |validator, artifacts, root|
+      # When: the link registries are generated
+      validator.generate_link_registries(artifacts)
+
+      # Then: the other language resolves the CV download to the default-language PDF
+      # No other language has pages, so only the default registry exists and it
+      # resolves the download to the default-language PDF without a marker.
+      german = registry(root, 'de')
+      assert_includes german, ":url_cv_pdf: {basedir}/cv.pdf\n"
+      assert_includes german, ":url_cv_marker:"
+    end
+  end
+
+  def test_cv_chrome_wording_is_resolved_by_the_page_it_lands_on
+    # Given: the shared CV chrome
+    includes_dir = Pathname.new(__dir__).join('../src-content/profile/includes')
+
+    # Then: it carries no wording of its own, only interface terms
+    CHROME.each do |name|
+      text = includes_dir.join(name).read
+      refute_match(/Software Architekt|Download CV|Projekte<|Weiterbildung<|Autor:/, text,
+                   "#{name} still carries its own wording")
+      assert_match(/\{ui_[a-z0-9_]+\}/, text, "#{name} should reference interface terms")
+    end
+  end
+
+  def test_cv_language_variant_is_blocked_until_its_fragments_are_translated
+    # Given: a CV language variant that includes a fragment available only in the default language
+    with_cv(
+      languages: {
+        'de' => "= CV\ninclude::{includesdir}/i18n/{lang}/profile/bio.adoc[]\n",
+        'en' => "= CV\ninclude::{includesdir}/i18n/{lang}/profile/bio.adoc[]\n"
+      },
+      fragments: { 'de/profile/bio.adoc' => "Deutscher Text\n" }
+    ) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated (done by the helper)
+      # Then: validation reports that the fragment is missing in the variant's language
+      assert validator.errors.any? { |error| error.match?(%r{fragment 'profile/bio\.adoc' is not available in 'en'}) },
+             "expected a missing-fragment error, got: #{validator.errors.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
Closes #56. Ninth slice of #47.

Brings the CV into the language model: its shared chrome follows the reader's language, and each CV language variant gets its own PDF.

Specified first: `features/multilingual-cv.feature`, bridged to `test/profile_cv_language_test.rb`.

## What this slice does *not* do — and why

**It does not produce an English CV.** Under ADR-010 fragments do not fall back, so a CV language variant is publishable only once *every* fragment it includes exists in that language. For the CV that is roughly 90 files: 12 professional-experience entries, 66 project entries, education, certificates, skills, languages, contact.

Those are real employers, real client projects and real dates. Translating them is authoring work about your career, not generator work, and I will not invent it. The mechanism is complete and proven; the content is yours to write.

The issue's acceptance criterion *"untranslated CV fragments fall back to German with the visible note"* is stale — it predates the ADR review where you decided fragments must not fall back. The corrected behaviour is a build error, and it has its own scenario.

## Changes

* 7 interface terms for the shared CV chrome; `cvheader.adoc`, `cvappendix.adoc`, `cvappendixnav.adoc` and `author.adoc` carry no wording of their own any more — asserted by a test.
* CV chrome links go through the link registry, including a new `{url_cv_pdf}` entry.
* `build.gradle` registers a PDF task per additional CV language present in the committed source tree. The HTML task already renders every language because it filters no sources.

## Two bugs this slice surfaced

**1. Ordering.** `cvheader.adoc` builds the document title block *before* it includes `docheader.adoc`, so the interface terms did not exist yet and the subtitle rendered literally as `{ui_cv_subtitle}` on three pages. Both headers now load the terms through one shared `i18n/cascade.adoc`, which also removes the duplicated lang-defaulting.

**2. Inconsistent language derivation.** The link registry took its language list from artifact metadata while its keys came from the file tree. A language whose pages carry no sidecar would have received no registry at all. Caught by the CV test, since the CV fixture has no sidecars.

## Verification

German output unchanged except the one page #55 already changed:

```
Only in build/site: en
index.html
```

`cv.pdf` content identical — same stream size, same text tokens; the binary differs only in metadata. `buildCVPersonal` produces its PDF unchanged.

| Check | Result |
|---|---|
| `profile_cv_language` | 4 runs, 25 assertions, 0 failures |
| `profile_language` | 33 runs, 97 assertions, 0 failures |
| `profile_language_alternates` | 3 runs, 14 assertions, 0 failures |
| `profile_translation` | 7 runs, 27 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 12 runs, 56 assertions, 0 failures |
| `profile_comments` | 7 runs, 60 assertions, 0 failures |
| `site_metadata_injector` | 11 runs, 28 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 0 errors |
| Architecture validator | 55 artifacts, 0 errors, 0 warnings |

## Note

`buildCVPersonal` (the personal PDF that is not deployed) stays German-only. It is a separate output with its own contact attributes; give it the same treatment when an English personal CV is actually wanted.
