### PR TITLE
issue_57: Publish the first English pages

### DIFF
--- a/features/article-listings.feature
+++ b/features/article-listings.feature
@@ -64,23 +64,14 @@ Feature: Article listings
     Then both generations produce identical listing files
 
   # Language variants of the listings. A reader who arrives on an English page
-  # and opens the article list should get English articles, and should be able to
-  # reach the other languages from there.
+  # and opens the article list gets English articles. Switching language is not
+  # part of the listing itself - it is the one language switcher in the page
+  # chrome, specified in features/language-alternates.feature.
 
   Scenario: Article listings are built per language
     Given published articles in two languages
     When the article listings are generated
     Then each language gets its own listing pages containing only its own articles
-
-  Scenario: Listing offers the same listing in the other languages
-    Given published articles in two languages
-    When the article listings are generated
-    Then each listing page links to the same listing in the other language and marks its own
-
-  Scenario: A language is only offered for a tag it actually uses
-    Given a tag used by articles in one language only
-    When the article listings are generated
-    Then that tag page offers no link to the language without such articles
 
   Scenario: Listing pages of a language subtree resolve their assets
     Given published articles in a language below the site root

--- a/features/article-listings.feature
+++ b/features/article-listings.feature
@@ -77,3 +77,18 @@ Feature: Article listings
     Given published articles in a language below the site root
     When the article listings are generated
     Then their pages point back to the site root from their own depth
+
+  # A listing titled "all articles" promises a complete set but shows one
+  # language. The note says which other languages publish articles, without
+  # claiming how many: a count would be wrong as soon as the other language has
+  # fewer, and it would have to be right per language, per tag and per skill.
+
+  Scenario: Listing names the other languages that publish articles
+    Given published articles in two languages
+    When the article listings are generated
+    Then each complete listing states that articles exist in the other language
+
+  Scenario: A listing of a tag used by one language only names no other language
+    Given a tag used by articles in one language only
+    When the article listings are generated
+    Then that tag listing states nothing about other languages

--- a/features/article-listings.feature
+++ b/features/article-listings.feature
@@ -62,3 +62,27 @@ Feature: Article listings
     Given a set of public articles with tags and skills
     When the article lists are generated twice
     Then both generations produce identical listing files
+
+  # Language variants of the listings. A reader who arrives on an English page
+  # and opens the article list should get English articles, and should be able to
+  # reach the other languages from there.
+
+  Scenario: Article listings are built per language
+    Given published articles in two languages
+    When the article listings are generated
+    Then each language gets its own listing pages containing only its own articles
+
+  Scenario: Listing offers the same listing in the other languages
+    Given published articles in two languages
+    When the article listings are generated
+    Then each listing page links to the same listing in the other language and marks its own
+
+  Scenario: A language is only offered for a tag it actually uses
+    Given a tag used by articles in one language only
+    When the article listings are generated
+    Then that tag page offers no link to the language without such articles
+
+  Scenario: Listing pages of a language subtree resolve their assets
+    Given published articles in a language below the site root
+    When the article listings are generated
+    Then their pages point back to the site root from their own depth

--- a/features/language-alternates.feature
+++ b/features/language-alternates.feature
@@ -22,6 +22,11 @@ Feature: Language alternates
     When the language switchers are generated
     Then each variant offers a link to the other and marks its own language as current
 
+  Scenario: Generated listing pages offer the switcher as well
+    Given published articles in two languages
+    When the language switchers are generated
+    Then the generated article listings of each language offer the switcher too
+
   Scenario: Page without a translation offers no language switcher
     Given a page that exists in the default language only
     When the language switchers are generated

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -252,27 +252,34 @@ class ProfileArtifactValidator
   def render_language_switcher(current, variants)
     ordered = variants.sort_by { |variant| artifact_language(variant) }
 
-    items = ordered.map do |variant|
+    entries = ordered.map do |variant|
       language = artifact_language(variant)
       flag = "{ui_language_flag_#{language}}"
       name = "{ui_language_name_#{language}}"
 
       if variant.equal?(current)
-        "        <li class=\"language-switch language-switch-current\">" \
-          "<span lang=\"#{language}\" title=\"#{name}\" aria-current=\"true\">#{flag}</span></li>"
+        "            <span class=\"language-switch-current\" lang=\"#{language}\" title=\"#{name}\" " \
+          "aria-current=\"true\">#{flag}</span>"
       else
         href = h(article_link_href(current, variant))
-        "        <li class=\"language-switch\">" \
-          "<a href=\"#{href}\" lang=\"#{language}\" hreflang=\"#{language}\" title=\"#{name}\" " \
-          "aria-label=\"#{name}\">#{flag}</a></li>"
+        "            <a href=\"#{href}\" lang=\"#{language}\" hreflang=\"#{language}\" title=\"#{name}\" " \
+          "aria-label=\"#{name}\">#{flag}</a>"
       end
     end
 
+    # One list item holding every language, rather than one item per language:
+    # the menu row sets a single gap for all its entries, so separate items could
+    # only be spaced apart by a negative margin that breaks whenever that gap
+    # changes between breakpoints.
+    #
     # Raw HTML without block delimiters: this file is included from inside the
     # menu's passthrough block, which already applies attribute substitution.
     # Splitting that block to include it as a block of its own would change the
     # whitespace of every rendered page.
-    [*items, ''].join("\n")
+    ['        <li class="language-switch">',
+     *entries,
+     '        </li>',
+     ''].join("\n")
   end
 
   def clean_generated_language_switchers

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -245,15 +245,26 @@ class ProfileArtifactValidator
     !artifact_output_path(artifact).nil?
   end
 
+  # List items for the main navigation, so the switcher sits in the menu row
+  # itself rather than as a separate block. The visible label is a flag; the
+  # language name stays on title and aria-label, because a flag alone is not an
+  # accessible name and stands for a country rather than a language.
   def render_language_switcher(current, variants)
     ordered = variants.sort_by { |variant| artifact_language(variant) }
+
     items = ordered.map do |variant|
       language = artifact_language(variant)
+      flag = "{ui_language_flag_#{language}}"
+      name = "{ui_language_name_#{language}}"
+
       if variant.equal?(current)
-        "    <li><span class=\"language-switch-current\" lang=\"#{language}\">{ui_language_name_#{language}}</span></li>"
+        "        <li class=\"language-switch language-switch-current\">" \
+          "<span lang=\"#{language}\" title=\"#{name}\" aria-current=\"true\">#{flag}</span></li>"
       else
         href = h(article_link_href(current, variant))
-        "    <li><a href=\"#{href}\" lang=\"#{language}\" hreflang=\"#{language}\">{ui_language_name_#{language}}</a></li>"
+        "        <li class=\"language-switch\">" \
+          "<a href=\"#{href}\" lang=\"#{language}\" hreflang=\"#{language}\" title=\"#{name}\" " \
+          "aria-label=\"#{name}\">#{flag}</a></li>"
       end
     end
 
@@ -261,12 +272,7 @@ class ProfileArtifactValidator
     # menu's passthrough block, which already applies attribute substitution.
     # Splitting that block to include it as a block of its own would change the
     # whitespace of every rendered page.
-    ['<nav class="language-switch" aria-label="{ui_language_switch_label}">',
-     '  <ul>',
-     *items,
-     '  </ul>',
-     '</nav>',
-     ''].join("\n")
+    [*items, ''].join("\n")
   end
 
   def clean_generated_language_switchers
@@ -1275,12 +1281,32 @@ class ProfileArtifactValidator
     slug.to_s.tr('-', ' ')
   end
 
-  # Common directory of all article sources; the listings live beneath it.
+  # The articles directory a set of articles belongs to; the listings live
+  # beneath it. Derived from the enclosing 'articles' directory rather than from
+  # the common ancestor of the sources: with a single article in one language the
+  # common ancestor is that article's own subdirectory, which would bury that
+  # language's listings one level too deep.
   def articles_base_dir(articles)
     dirs = articles.map { |article| article_source_path(article).dirname }
     return nil if dirs.empty?
 
+    roots = dirs.filter_map { |dir| enclosing_articles_dir(dir) }.uniq
+    return roots.min_by { |dir| dir.to_s.length } unless roots.empty?
+
     dirs.reduce { |common, dir| common_ancestor(common, dir) }
+  end
+
+  # Nearest ancestor directory named 'articles', or nil when the sources do not
+  # follow that convention.
+  def enclosing_articles_dir(dir)
+    current = dir
+    until current.basename.to_s == 'articles'
+      parent = current.parent
+      return nil if parent == current
+
+      current = parent
+    end
+    current
   end
 
   def common_ancestor(first, second)
@@ -1481,7 +1507,14 @@ class ProfileArtifactValidator
 
   def related_articles(article, all_articles)
     self_id = article.metadata['id']
-    excluded = [self_id, article.metadata['previous'], article.metadata['next']].compact.to_set
+    # Translations of this article are excluded along with the article itself.
+    # They share its tags, and resolving a suggestion to the reader's language
+    # would otherwise turn a variant of this very article into a recommendation
+    # to read it.
+    self_group = translation_group_key(article)
+    own_variants = all_articles.select { |candidate| translation_group_key(candidate) == self_group }
+                               .map { |candidate| candidate.metadata['id'] }
+    excluded = (own_variants + [self_id, article.metadata['previous'], article.metadata['next']]).compact.to_set
     self_tags = meaningful_tags(article)
     linked = related_relation_ids(article, all_articles)
 

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -166,6 +166,15 @@ class ProfileArtifactValidator
 
     by_language = all_articles.group_by { |article| artifact_language(article) }
 
+    @languages_with_articles = by_language.keys
+    @tag_languages = Hash.new { |hash, key| hash[key] = [] }
+    @skill_languages = Hash.new { |hash, key| hash[key] = [] }
+    by_language.each do |language, articles|
+      ordered = public_articles(articles)
+      tags_in_use(ordered).each { |tag| @tag_languages[tag] << language }
+      skills_in_use(ordered).each { |skill| @skill_languages[skill] << language }
+    end
+
     by_language.flat_map do |language, articles|
       generate_article_lists_for(articles, language)
     end
@@ -195,7 +204,8 @@ class ProfileArtifactValidator
 
     all_path = pages_dir.join('all.adoc')
     all_path.write(render_list_page(title: terms.fetch('ui_article_list_all'), articles: ordered,
-                                    output_dir: output_dir, articles_dir: articles_dir, language: language),
+                                    output_dir: output_dir, articles_dir: articles_dir, language: language,
+                                    other_languages: @languages_with_articles - [language]),
                    encoding: 'UTF-8')
     written << all_path
 
@@ -204,7 +214,8 @@ class ProfileArtifactValidator
       path = pages_dir.join("tag-#{tag}.adoc")
       title = "#{terms.fetch('ui_article_list_tag_prefix')} #{tag}"
       path.write(render_list_page(title: title, articles: tagged, output_dir: output_dir,
-                                  articles_dir: articles_dir, language: language),
+                                  articles_dir: articles_dir, language: language,
+                                  other_languages: @tag_languages[tag] - [language]),
                  encoding: 'UTF-8')
       written << path
     end
@@ -214,7 +225,8 @@ class ProfileArtifactValidator
       path = pages_dir.join("skill-#{skill}.adoc")
       title = "#{terms.fetch('ui_article_list_skill_prefix')} #{humanize_slug(skill)}"
       path.write(render_list_page(title: title, articles: skilled, output_dir: output_dir,
-                                  articles_dir: articles_dir, language: language),
+                                  articles_dir: articles_dir, language: language,
+                                  other_languages: @skill_languages[skill] - [language]),
                  encoding: 'UTF-8')
       written << path
     end
@@ -1390,9 +1402,25 @@ class ProfileArtifactValidator
      ''].join("\n")
   end
 
-  def render_list_page(title:, articles:, output_dir:, articles_dir:, language:)
-    body = ['<p class="article-list-back"><a href="../articles.html">&#8592; {ui_article_list_back}</a></p>',
-            article_list_html(articles, from_dir: output_dir, articles_dir: articles_dir, language: language)].join("\n")
+  # Names the other languages that publish articles for this listing. Deliberately
+  # without a count: a number would be a claim about how much is on the other side,
+  # and 'one further article' is already wrong when that language has fewer. Naming
+  # the languages stays true for any number of articles and any number of languages.
+  def other_languages_note(language, others, terms)
+    return '' if others.empty?
+
+    names = others.sort.map { |other| terms.fetch("ui_language_name_#{other}", other) }
+    sentence = terms.fetch('ui_article_list_other_languages', '').sub('%languages%', names.join(', '))
+    return '' if sentence.empty?
+
+    "<p class=\"article-list-languages\">#{h(sentence)}</p>"
+  end
+
+  def render_list_page(title:, articles:, output_dir:, articles_dir:, language:, other_languages: [])
+    body = [other_languages_note(language, other_languages, ui_terms_values(language)),
+            '<p class="article-list-back"><a href="../articles.html">&#8592; {ui_article_list_back}</a></p>',
+            article_list_html(articles, from_dir: output_dir, articles_dir: articles_dir, language: language)]
+           .reject(&:empty?).join("\n")
 
     ['// Generated article list page. Do not edit manually.',
      "= #{title}",

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -166,62 +166,12 @@ class ProfileArtifactValidator
 
     by_language = all_articles.group_by { |article| artifact_language(article) }
 
-    # Every language that has articles, with the site-root-relative location of
-    # its article directory. Listing pages use it to offer the same listing in
-    # the other languages, so a reader is not stuck in the language they landed in.
-    language_roots = by_language.filter_map do |language, articles|
-      dir = articles_base_dir(articles)
-      relative = dir && site_relative_dir(dir)
-      [language, relative.to_s] if relative
-    end.to_h
-
-    @tag_languages = Hash.new { |hash, key| hash[key] = [] }
-    @skill_languages = Hash.new { |hash, key| hash[key] = [] }
-    by_language.each do |language, articles|
-      ordered = public_articles(articles)
-      tags_in_use(ordered).each { |tag| @tag_languages[tag] << language }
-      skills_in_use(ordered).each { |skill| @skill_languages[skill] << language }
-    end
-
     by_language.flat_map do |language, articles|
-      generate_article_lists_for(articles, language, language_roots)
+      generate_article_lists_for(articles, language)
     end
   end
 
-  # Sub-navigation offering the same listing in every language that has articles.
-  # Hrefs are {basedir}-relative, so one fragment works from the landing page and
-  # from the listing pages alike, which sit at different depths.
-  def render_language_nav(current_language, language_roots, page)
-    return '' if language_roots.length < 2
-
-    items = language_roots.keys.sort.map do |language|
-      label = "{ui_articles_in_#{language}}"
-      if language == current_language
-        "        <li><span class=\"language-nav-current\" aria-current=\"true\">#{label}</span></li>"
-      else
-        href = ['{basedir}', language_roots[language], page].reject(&:empty?).join('/')
-        "        <li><a href=\"#{href}\">#{label}</a></li>"
-      end
-    end
-
-    ['<nav class="subnav noborder language-nav" aria-label="{ui_article_list_languages}">',
-     '    <ul>',
-     *items,
-     '    </ul>',
-     '</nav>'].join("\n")
-  end
-
-  # Languages whose public articles use a given tag or skill. A language is only
-  # offered for a tag page it actually has articles for.
-  def tag_languages(tag)
-    @tag_languages.fetch(tag, [])
-  end
-
-  def skill_languages(skill)
-    @skill_languages.fetch(skill, [])
-  end
-
-  def generate_article_lists_for(articles, language, language_roots = {})
+  def generate_article_lists_for(articles, language)
     articles_dir = articles_base_dir(articles)
     return [] if articles_dir.nil?
 
@@ -239,26 +189,13 @@ class ProfileArtifactValidator
     ordered = sort_articles(public_articles(articles))
     written = []
 
-    # Language sub-navigation for the authored article landing page, which sits
-    # at a different depth than the generated listing pages and therefore cannot
-    # share their embedded copy.
-    languages_path = lists_dir.join('languages.adoc')
-    landing_nav = render_language_nav(language, language_roots, 'articles.html')
-    languages_path.write(
-      landing_nav.empty? ? '' : ['// Generated language navigation. Do not edit manually.',
-                                 '[subs="attributes"]', '++++', landing_nav, '++++', ''].join("\n"),
-      encoding: 'UTF-8'
-    )
-    written << languages_path
-
     recent_path = lists_dir.join('recent.adoc')
     recent_path.write(render_list_fragment(ordered.first(RECENT_LIMIT), from_dir: articles_dir, language: language), encoding: 'UTF-8')
     written << recent_path
 
     all_path = pages_dir.join('all.adoc')
-    all_path.write(render_list_page(title: terms.fetch('ui_article_list_all'), articles: ordered, output_dir: output_dir,
-                                    articles_dir: articles_dir, language: language,
-                                    language_nav: render_language_nav(language, language_roots, 'lists/all.html')),
+    all_path.write(render_list_page(title: terms.fetch('ui_article_list_all'), articles: ordered,
+                                    output_dir: output_dir, articles_dir: articles_dir, language: language),
                    encoding: 'UTF-8')
     written << all_path
 
@@ -266,12 +203,8 @@ class ProfileArtifactValidator
       tagged = ordered.select { |article| Array(article.metadata['tags']).include?(tag) }
       path = pages_dir.join("tag-#{tag}.adoc")
       title = "#{terms.fetch('ui_article_list_tag_prefix')} #{tag}"
-      # Only languages that actually use this tag are offered; linking a language
-      # to a tag page it has no articles for would lead to a page that is not there.
-      tag_roots = language_roots.select { |other, _| other == language || tag_languages(tag).include?(other) }
       path.write(render_list_page(title: title, articles: tagged, output_dir: output_dir,
-                                  articles_dir: articles_dir, language: language,
-                                  language_nav: render_language_nav(language, tag_roots, "lists/tag-#{tag}.html")),
+                                  articles_dir: articles_dir, language: language),
                  encoding: 'UTF-8')
       written << path
     end
@@ -280,10 +213,8 @@ class ProfileArtifactValidator
       skilled = ordered.select { |article| Array(article.metadata['skills']).include?(skill) }
       path = pages_dir.join("skill-#{skill}.adoc")
       title = "#{terms.fetch('ui_article_list_skill_prefix')} #{humanize_slug(skill)}"
-      skill_roots = language_roots.select { |other, _| other == language || skill_languages(skill).include?(other) }
       path.write(render_list_page(title: title, articles: skilled, output_dir: output_dir,
-                                  articles_dir: articles_dir, language: language,
-                                  language_nav: render_language_nav(language, skill_roots, "lists/skill-#{skill}.html")),
+                                  articles_dir: articles_dir, language: language),
                  encoding: 'UTF-8')
       written << path
     end
@@ -295,20 +226,62 @@ class ProfileArtifactValidator
   # really exists in more than one language. A page that merely falls back to the
   # default language is not offered as a variant: that would promise a
   # translation nobody wrote.
-  def generate_language_switchers(artifacts)
+  # Derived from the page tree rather than from metadata: the article overview
+  # and the generated listings are real pages a reader can land on, but they carry
+  # no sidecar. Basing the switcher on artifacts left exactly those pages without
+  # one, which is what made a second, differently shaped switcher look necessary.
+  def generate_language_switchers(_artifacts = nil)
     clean_generated_language_switchers
 
-    groups = translation_groups(artifacts)
+    (page_language_groups.values + listing_language_groups.values)
+      .select { |variants| variants.length > 1 }
+      .flat_map { |variants| write_language_switchers(variants) }
+  end
 
-    groups.values.select { |variants| variants.length > 1 }.flat_map do |variants|
-      variants.map do |variant|
-        dir = article_source_path(variant).dirname.join('generated')
-        FileUtils.mkdir_p(dir)
-        path = dir.join("#{article_slug(variant)}-langswitch.adoc")
-        path.write(render_language_switcher(variant, variants), encoding: 'UTF-8')
-        path
+  # One switcher per variant, written next to its source so the fixed include in
+  # the page chrome resolves per page.
+  def write_language_switchers(variants)
+    variants.map do |language, source|
+      dir = source.dirname.join('generated')
+      FileUtils.mkdir_p(dir)
+      path = dir.join("#{source.basename('.adoc')}-langswitch.adoc")
+      path.write(render_language_switcher(language, variants, source), encoding: 'UTF-8')
+      path
+    end
+  end
+
+  # Authored pages grouped by what they are, regardless of language: two pages
+  # are variants when their output paths differ only by the language prefix.
+  def page_language_groups
+    site_pages.each_with_object({}) do |(output, source), groups|
+      language = output_language(output)
+      neutral = language == DEFAULT_LANGUAGE ? output : output.delete_prefix("#{language}/")
+      (groups[neutral] ||= {})[language] = Pathname.new(source)
+    end
+  end
+
+  # The generated listing pages, grouped the same way. They are generated before
+  # the switchers, so their sources can be read from disk.
+  def listing_language_groups
+    groups = {}
+
+    SITE_SOURCE_ROOTS.each do |source_root|
+      Dir.glob(profile_dir.join(source_root, '**', 'generated', 'pages', '*.adoc').to_s).sort.each do |path|
+        source = Pathname.new(path)
+        relative = site_relative_dir(source.dirname)
+        next if relative.nil?
+
+        language = output_language(relative.to_s)
+        (groups["listing:#{source.basename}"] ||= {})[language] = source
       end
     end
+
+    groups
+  end
+
+  def output_language(output_path)
+    prefix = output_path.to_s.split('/').first
+    LANGUAGES.include?(prefix) && prefix != DEFAULT_LANGUAGE ? prefix : DEFAULT_LANGUAGE
   end
 
   # Artifacts that are translations of one another, keyed by their group, and
@@ -326,19 +299,16 @@ class ProfileArtifactValidator
   # itself rather than as a separate block. The visible label is a flag; the
   # language name stays on title and aria-label, because a flag alone is not an
   # accessible name and stands for a country rather than a language.
-  def render_language_switcher(current, variants)
-    ordered = variants.sort_by { |variant| artifact_language(variant) }
-
-    entries = ordered.map do |variant|
-      language = artifact_language(variant)
+  def render_language_switcher(current_language, variants, current_source)
+    entries = variants.keys.sort.map do |language|
       flag = "{ui_language_flag_#{language}}"
       name = "{ui_language_name_#{language}}"
 
-      if variant.equal?(current)
+      if language == current_language
         "            <span class=\"language-switch-current\" lang=\"#{language}\" title=\"#{name}\" " \
           "aria-current=\"true\">#{flag}</span>"
       else
-        href = h(article_link_href(current, variant))
+        href = h(page_link_href(current_source, variants[language]))
         "            <a href=\"#{href}\" lang=\"#{language}\" hreflang=\"#{language}\" title=\"#{name}\" " \
           "aria-label=\"#{name}\">#{flag}</a>"
       end
@@ -1420,11 +1390,9 @@ class ProfileArtifactValidator
      ''].join("\n")
   end
 
-  def render_list_page(title:, articles:, output_dir:, articles_dir:, language:, language_nav: '')
-    body = [language_nav,
-            '<p class="article-list-back"><a href="../articles.html">&#8592; {ui_article_list_back}</a></p>',
-            article_list_html(articles, from_dir: output_dir, articles_dir: articles_dir, language: language)]
-           .reject(&:empty?).join("\n")
+  def render_list_page(title:, articles:, output_dir:, articles_dir:, language:)
+    body = ['<p class="article-list-back"><a href="../articles.html">&#8592; {ui_article_list_back}</a></p>',
+            article_list_html(articles, from_dir: output_dir, articles_dir: articles_dir, language: language)].join("\n")
 
     ['// Generated article list page. Do not edit manually.',
      "= #{title}",
@@ -1702,6 +1670,27 @@ class ProfileArtifactValidator
 
     article = by_id[id]
     article if article && article.metadata['type'] == 'Article'
+  end
+
+  # Relative href between two pages, computed on their rendered locations rather
+  # than their sources. Generated listing pages are authored under
+  # 'generated/pages' but rendered into 'lists', so source paths would give the
+  # wrong depth.
+  def page_link_href(from_source, to_source)
+    from = page_output_path(from_source)
+    to = page_output_path(to_source)
+    to.relative_path_from(from.dirname).to_s
+  end
+
+  def page_output_path(source)
+    dir = source.dirname
+    return dir.parent.parent.join('lists', source.basename('.adoc').to_s + '.html') if listing_source?(dir)
+
+    source.sub_ext('.html')
+  end
+
+  def listing_source?(dir)
+    dir.basename.to_s == 'pages' && dir.parent.basename.to_s == 'generated'
   end
 
   def article_link_href(from_article, to_article)

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -164,12 +164,64 @@ class ProfileArtifactValidator
     all_articles = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
     return [] if all_articles.empty?
 
-    all_articles.group_by { |article| artifact_language(article) }.flat_map do |language, articles|
-      generate_article_lists_for(articles, language)
+    by_language = all_articles.group_by { |article| artifact_language(article) }
+
+    # Every language that has articles, with the site-root-relative location of
+    # its article directory. Listing pages use it to offer the same listing in
+    # the other languages, so a reader is not stuck in the language they landed in.
+    language_roots = by_language.filter_map do |language, articles|
+      dir = articles_base_dir(articles)
+      relative = dir && site_relative_dir(dir)
+      [language, relative.to_s] if relative
+    end.to_h
+
+    @tag_languages = Hash.new { |hash, key| hash[key] = [] }
+    @skill_languages = Hash.new { |hash, key| hash[key] = [] }
+    by_language.each do |language, articles|
+      ordered = public_articles(articles)
+      tags_in_use(ordered).each { |tag| @tag_languages[tag] << language }
+      skills_in_use(ordered).each { |skill| @skill_languages[skill] << language }
+    end
+
+    by_language.flat_map do |language, articles|
+      generate_article_lists_for(articles, language, language_roots)
     end
   end
 
-  def generate_article_lists_for(articles, language)
+  # Sub-navigation offering the same listing in every language that has articles.
+  # Hrefs are {basedir}-relative, so one fragment works from the landing page and
+  # from the listing pages alike, which sit at different depths.
+  def render_language_nav(current_language, language_roots, page)
+    return '' if language_roots.length < 2
+
+    items = language_roots.keys.sort.map do |language|
+      label = "{ui_articles_in_#{language}}"
+      if language == current_language
+        "        <li><span class=\"language-nav-current\" aria-current=\"true\">#{label}</span></li>"
+      else
+        href = ['{basedir}', language_roots[language], page].reject(&:empty?).join('/')
+        "        <li><a href=\"#{href}\">#{label}</a></li>"
+      end
+    end
+
+    ['<nav class="subnav noborder language-nav" aria-label="{ui_article_list_languages}">',
+     '    <ul>',
+     *items,
+     '    </ul>',
+     '</nav>'].join("\n")
+  end
+
+  # Languages whose public articles use a given tag or skill. A language is only
+  # offered for a tag page it actually has articles for.
+  def tag_languages(tag)
+    @tag_languages.fetch(tag, [])
+  end
+
+  def skill_languages(skill)
+    @skill_languages.fetch(skill, [])
+  end
+
+  def generate_article_lists_for(articles, language, language_roots = {})
     articles_dir = articles_base_dir(articles)
     return [] if articles_dir.nil?
 
@@ -187,19 +239,40 @@ class ProfileArtifactValidator
     ordered = sort_articles(public_articles(articles))
     written = []
 
+    # Language sub-navigation for the authored article landing page, which sits
+    # at a different depth than the generated listing pages and therefore cannot
+    # share their embedded copy.
+    languages_path = lists_dir.join('languages.adoc')
+    landing_nav = render_language_nav(language, language_roots, 'articles.html')
+    languages_path.write(
+      landing_nav.empty? ? '' : ['// Generated language navigation. Do not edit manually.',
+                                 '[subs="attributes"]', '++++', landing_nav, '++++', ''].join("\n"),
+      encoding: 'UTF-8'
+    )
+    written << languages_path
+
     recent_path = lists_dir.join('recent.adoc')
     recent_path.write(render_list_fragment(ordered.first(RECENT_LIMIT), from_dir: articles_dir, language: language), encoding: 'UTF-8')
     written << recent_path
 
     all_path = pages_dir.join('all.adoc')
-    all_path.write(render_list_page(title: terms.fetch('ui_article_list_all'), articles: ordered, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
+    all_path.write(render_list_page(title: terms.fetch('ui_article_list_all'), articles: ordered, output_dir: output_dir,
+                                    articles_dir: articles_dir, language: language,
+                                    language_nav: render_language_nav(language, language_roots, 'lists/all.html')),
+                   encoding: 'UTF-8')
     written << all_path
 
     tags_in_use(ordered).each do |tag|
       tagged = ordered.select { |article| Array(article.metadata['tags']).include?(tag) }
       path = pages_dir.join("tag-#{tag}.adoc")
       title = "#{terms.fetch('ui_article_list_tag_prefix')} #{tag}"
-      path.write(render_list_page(title: title, articles: tagged, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
+      # Only languages that actually use this tag are offered; linking a language
+      # to a tag page it has no articles for would lead to a page that is not there.
+      tag_roots = language_roots.select { |other, _| other == language || tag_languages(tag).include?(other) }
+      path.write(render_list_page(title: title, articles: tagged, output_dir: output_dir,
+                                  articles_dir: articles_dir, language: language,
+                                  language_nav: render_language_nav(language, tag_roots, "lists/tag-#{tag}.html")),
+                 encoding: 'UTF-8')
       written << path
     end
 
@@ -207,7 +280,11 @@ class ProfileArtifactValidator
       skilled = ordered.select { |article| Array(article.metadata['skills']).include?(skill) }
       path = pages_dir.join("skill-#{skill}.adoc")
       title = "#{terms.fetch('ui_article_list_skill_prefix')} #{humanize_slug(skill)}"
-      path.write(render_list_page(title: title, articles: skilled, output_dir: output_dir, articles_dir: articles_dir, language: language), encoding: 'UTF-8')
+      skill_roots = language_roots.select { |other, _| other == language || skill_languages(skill).include?(other) }
+      path.write(render_list_page(title: title, articles: skilled, output_dir: output_dir,
+                                  articles_dir: articles_dir, language: language,
+                                  language_nav: render_language_nav(language, skill_roots, "lists/skill-#{skill}.html")),
+                 encoding: 'UTF-8')
       written << path
     end
 
@@ -1343,14 +1420,17 @@ class ProfileArtifactValidator
      ''].join("\n")
   end
 
-  def render_list_page(title:, articles:, output_dir:, articles_dir:, language:)
-    body = ['<p class="article-list-back"><a href="../articles.html">&#8592; Zurück zur Artikelübersicht</a></p>',
-            article_list_html(articles, from_dir: output_dir, articles_dir: articles_dir, language: language)].join("\n")
+  def render_list_page(title:, articles:, output_dir:, articles_dir:, language:, language_nav: '')
+    body = [language_nav,
+            '<p class="article-list-back"><a href="../articles.html">&#8592; {ui_article_list_back}</a></p>',
+            article_list_html(articles, from_dir: output_dir, articles_dir: articles_dir, language: language)]
+           .reject(&:empty?).join("\n")
 
     ['// Generated article list page. Do not edit manually.',
      "= #{title}",
+     ':lang: ' + language,
      'ifdef::buildsite[]',
-     ':basedir: ../..',
+     ":basedir: #{site_root_relative_prefix(output_dir)}",
      'endif::[]',
      'include::{includesdir}/../../revinfo.adoc[]',
      ':revdate!:',
@@ -1359,10 +1439,35 @@ class ProfileArtifactValidator
      ':active: articles',
      'include::{includesdir}/docheader.adoc[]',
      '',
+     '[subs="attributes"]',
      '++++',
      body,
      '++++',
      ''].join("\n")
+  end
+
+  # Relative prefix from an output directory back to the site root, used as
+  # {basedir}. A hard-coded '../..' only holds for the default language, which
+  # sits directly under the site root; a language subtree is one level deeper and
+  # would resolve its stylesheet and menu links inside its own directory.
+  def site_root_relative_prefix(output_dir)
+    relative = site_relative_dir(output_dir)
+    return '../..' if relative.nil?
+
+    depth = relative.each_filename.count
+    depth.zero? ? '.' : Array.new(depth, '..').join('/')
+  end
+
+  # Path of a directory relative to the site root it belongs to, or nil when it
+  # is outside the rendered source roots.
+  def site_relative_dir(dir)
+    SITE_SOURCE_ROOTS.each do |source_root|
+      root = profile_dir.join(source_root)
+      next unless dir.to_s == root.to_s || dir.to_s.start_with?("#{root}/")
+
+      return dir.relative_path_from(root)
+    end
+    nil
   end
 
   def article_list_html(articles, from_dir:, articles_dir:, language:)

--- a/src-content/profile/includes/i18n/en/profile/about_me_citations.adoc
+++ b/src-content/profile/includes/i18n/en/profile/about_me_citations.adoc
@@ -1,0 +1,15 @@
+[discrete]
+=== What colleagues say about me
+
+[quote, Colleagues]
+____
+"You are a wonderful person and I think it is great to know you. You always listen, and you radiate an incredible calm and composure."
+
+"What I value most about you is your composure and your honest, direct manner, which I find genuinely authentic and full of integrity."
+
+"Dieter, you are the 'Sempi from Frankfurt'. Experienced, unflappable, and admired by younger colleagues."
+
+"That relaxed way of tackling things is simply brilliant."
+
+"Dieter, you are helpful, open and honest. You are someone people can rely on."
+____

--- a/src-content/profile/includes/i18n/en/profile/profile.adoc
+++ b/src-content/profile/includes/i18n/en/profile/profile.adoc
@@ -1,0 +1,36 @@
+:includeskillmatrix: true
+ifeval::['{backend}' == 'pdf']
+:includeskillmatrix: false
+endif::[]
+
+[discrete]
+== Profile
+
+For over *30 years* I have worked in software development, focusing on the *architecture and integration of complex application systems*.
+
+My career began as a software developer and led, by way of international integration projects, to *software architect and IT consultant*. During the 1990s I worked for *Uniquare (then Genesis)* as a *systems integrator and technical coach* on banking projects in *South Africa, Moscow and Kuala Lumpur*.
+
+Today I help companies design and build *distributed, process-oriented systems*, with a focus on *Domain-Driven Design, Clean Architecture, Event-Driven Architecture and sustainable architecture documentation*.
+
+*Since 2020* I have supported my colleagues as a trainer for the *iSAQB Certified Software Architect - Foundation Level* whenever a trainer is needed.
+
+I am also increasingly concerned with *sustainability in software architecture*, in particular the *effect of IT systems on energy consumption and the environment*.
+
+ifeval::['{includeskillmatrix}' == 'true']
+[discrete]
+=== Skills
+
+include::../skills/skills_matrix.adoc[]
+endif::[]
+
+[discrete]
+=== How I work
+
+* Connecting *architecture work and hands-on development*
+* *Pragmatic use of agile methods*
+* *Coaching and sharing knowledge* within development teams
+* *Sustainable architecture documentation*
+
+Good software grows out of the *dialogue between technology, business and users* - and that intersection is where I see my role.
+
+I combine *architecture work, hands-on development and comprehensible documentation* to build *sustainable and maintainable software systems*.

--- a/src-content/profile/includes/i18n/en/profile/profile_personal.adoc
+++ b/src-content/profile/includes/i18n/en/profile/profile_personal.adoc
@@ -1,0 +1,4 @@
+[discrete]
+=== Personal commitment
+
+For *personal reasons*, the subject of *inclusion* matters a great deal to me. I advocate a working culture that encourages diversity and removes barriers - in professional life and beyond.

--- a/src-content/profile/includes/i18n/en/skills/skills_matrix.adoc
+++ b/src-content/profile/includes/i18n/en/skills/skills_matrix.adoc
@@ -1,0 +1,82 @@
+:badge_color: blue
+
+:skill_documentation_title: Documentation
+:skill_documentation_badge_color: green
+:skill_documentation_1: arc42 - Confluence / Notion / docToolchain
+:skill_documentation_1_badge: arc42_Confluence_Notion_docToolchain
+
+:skill_integration_title: Integration
+:skill_integration_badge_color: yellow
+:skill_integration_1: Apache Kafka
+:skill_integration_1_badge: Apache_Kafka
+:skill_integration_2: Messaging
+:skill_integration_2_badge: Messaging
+:skill_integration_3: REST / APIs
+:skill_integration_3_badge: REST_APIs
+:skill_integration_4: BPM - Camunda
+:skill_integration_4_badge: BPM_Camunda
+
+:skill_development_title: Development
+:skill_development_badge_color: orange
+:skill_development_1: Java / Spring Boot
+:skill_development_1_badge: Java,_Spring_Boot
+:skill_development_2: React / Typescript
+:skill_development_2_badge: React_Typescript
+:skill_development_3: REST Services
+:skill_development_3_badge: REST_Services
+
+:skill_architecture_title: Software Architecture
+:skill_architecture_badge_color: {badge_color}
+:skill_architecture_1: Domain Driven Design
+:skill_architecture_1_badge: Domain_Driven_Design
+:skill_architecture_2: Clean Architecture
+:skill_architecture_2_badge: Clean_Architecture
+:skill_architecture_3: Event Driven Architecture
+:skill_architecture_3_badge: Event_Driven_Architecture
+
+:skill_methods_title: Methods
+:skill_methods_badge_color: grey
+:skill_methods_1: Agile Collaboration
+:skill_methods_1_badge: Agile_Collaboration
+:skill_methods_2: Coaching / Training
+:skill_methods_2_badge: Coaching,_Training
+:skill_methods_docascode: Doc as Code
+:skill_methods_docascode_badge: Doc_as_Code
+:skill_methods_4: Clean Code
+:skill_methods_4_badge: Clean_Code
+:skill_methods_5: Architecture Communication
+:skill_methods_5_badge: Architektur_Kommunikation
+
+:skill_platform_title: Platform & Delivery
+:skill_platform_badge_color: yellowgreen
+:skill_platform_1: Docker / Kubernetes
+:skill_platform_1_badge: Docker,_Kubernetes
+:skill_platform_2: Helm
+:skill_platform_2_badge: Helm
+:skill_platform_cicd: CI/CD Pipelines (Jenkins / GitLab / GitHub)
+:skill_platform_cicd_badge: CI_CD,_Pipelines_Jenkins_GitLab_GitHub
+:skill_platform_4: AWS / Azure
+:skill_platform_4_badge: AWS_Azure
+
+:skill_branches_title: Industries
+:skill_branches_badge_color: lightgrey
+:skill_branches_1: Banking / Insurance | Transport | Public Administration
+:skill_branches_1_badge: Banken_Versicherungen_Transport_Oeffentliche_Verwaltung
+
+:htmlmatrix: true
+ifeval::["{backend}" != "html5"]
+:htmlmatrix: false
+endif::[]
+
+ifeval::["{htmlmatrix}" == "true"]
+include::./skills_matrix_site.adoc[]
+endif::[]
+
+ifeval::["{htmlmatrix}" == "false"]
+ifeval::["{type}" == "readme"]
+include::./skills_matrix_readme.adoc[]
+endif::[]
+ifeval::["{type}" != "readme"]
+include::./skills_matrix_pdf.adoc[]
+endif::[]
+endif::[]

--- a/src-content/profile/includes/i18n/en/skills/skills_matrix_pdf.adoc
+++ b/src-content/profile/includes/i18n/en/skills/skills_matrix_pdf.adoc
@@ -1,0 +1,21 @@
+
+*{skill_documentation_title}* +
+{skill_documentation_1}
+
+*{skill_integration_title}* +
+{skill_integration_1} | {skill_integration_2} | {skill_integration_3} | {skill_integration_4}
+
+*{skill_development_title}* +
+{skill_development_1} | {skill_development_2} | {skill_development_3}
+
+*{skill_architecture_title}* +
+{skill_architecture_1} | {skill_architecture_2} | {skill_architecture_3}
+
+*{skill_methods_title}* +
+{skill_methods_1} | {skill_methods_2} | {skill_methods_docascode} | {skill_methods_4} | {skill_methods_5}
+
+*{skill_platform_title}* +
+{skill_platform_1} | {skill_platform_2} | {skill_platform_cicd} | {skill_platform_4}
+
+*{skill_branches_title}* +
+{skill_branches_1}

--- a/src-content/profile/includes/i18n/en/skills/skills_matrix_readme.adoc
+++ b/src-content/profile/includes/i18n/en/skills/skills_matrix_readme.adoc
@@ -1,0 +1,23 @@
+:img_shields_io: https://img.shields.io/badge
+
+*{skill_documentation_title}* +
+!link:{img_shields_io}/{skill_documentation_1_badge}-{skill_documentation_badge_color}[{skill_documentation_1}]
+
+*{skill_integration_title}* +
+!link:{img_shields_io}/{skill_integration_1_badge}-{skill_integration_badge_color}[{skill_integration_1}] !link:{img_shields_io}/{skill_integration_2_badge}-{skill_integration_badge_color}[{skill_integration_2}] !link:{img_shields_io}/{skill_integration_3_badge}-{skill_integration_badge_color}[{skill_integration_3}] !link:{img_shields_io}/{skill_integration_4_badge}-{skill_integration_badge_color}[{skill_integration_4}]
+
+*{skill_development_title}* +
+!link:{img_shields_io}/{skill_development_1_badge}-{skill_development_badge_color}[{skill_development_1}] !link:{img_shields_io}/{skill_development_2_badge}-{skill_development_badge_color}[{skill_development_2}] !link:{img_shields_io}/{skill_development_3_badge}-{skill_development_badge_color}[{skill_development_3}]
+
+*{skill_architecture_title}* +
+!link:{img_shields_io}/{skill_architecture_1_badge}-{skill_architecture_badge_color}[{skill_architecture_1}] !link:{img_shields_io}/{skill_architecture_2_badge}-{skill_architecture_badge_color}[{skill_architecture_2}] !link:{img_shields_io}/{skill_architecture_3_badge}-{skill_architecture_badge_color}[{skill_architecture_3}]
+
+*{skill_methods_title}* +
+!link:{img_shields_io}/{skill_methods_1_badge}-{skill_methods_badge_color}[{skill_methods_1}] !link:{img_shields_io}/{skill_methods_2_badge}-{skill_methods_badge_color}[{skill_methods_2}] !link:{img_shields_io}/{skill_methods_docascode_badge}-{skill_methods_badge_color}[{skill_methods_docascode}] !link:{img_shields_io}/{skill_methods_4_badge}-{skill_methods_badge_color}[{skill_methods_4}] !link:{img_shields_io}/{skill_methods_5_badge}-{skill_methods_badge_color}[{skill_methods_5}]
+
+*{skill_platform_title}* +
+!link:{img_shields_io}/{skill_platform_1_badge}-{skill_platform_badge_color}[{skill_platform_1}] !link:{img_shields_io}/{skill_platform_2_badge}-{skill_platform_badge_color}[{skill_platform_2}] !link:{img_shields_io}/{skill_platform_cicd_badge}-{skill_platform_badge_color}[{skill_platform_cicd}] !link:{img_shields_io}/{skill_platform_4_badge}-{skill_platform_badge_color}[{skill_platform_4}]
+
+*{skill_branches_title}* +
+!link:{img_shields_io}/{skill_branches_1_badge}-{skill_branches_badge_color}[{skill_branches_1}]
+

--- a/src-content/profile/includes/i18n/en/skills/skills_matrix_site.adoc
+++ b/src-content/profile/includes/i18n/en/skills/skills_matrix_site.adoc
@@ -1,0 +1,84 @@
+ifndef::stylesheet[]
+:stylesheet: style.css
+:stylesdir: ../../../theme
+endif::[]
+
+:compact-class: compact
+ifeval::["{type}" != "cv"]
+:compact-class!:
+endif::[]
+
+[subs=attributes,macros]
+++++
+<div class="skillrow {compact-class}">
+    <div class="skillbox">
+        <strong>{skill_documentation_title}</strong><br>
+         {skill_documentation_1}<br>
+    </div>
+</div>
+
+<div class="skillrow {compact-class}">
+    <div class="skillbox">
+        <strong>{skill_integration_title}</strong><br>
+        {skill_integration_1}<br>
+        {skill_integration_3}<br>
+        {skill_integration_4}<br>
+    </div>
+    <div class="skillbox">
+        <strong>{skill_development_title}</strong><br>
+        {skill_development_1}<br>
+        {skill_development_2}<br>
+        {skill_development_3}
+    </div>
+</div>
+
+<div class="skillrow {compact-class}">
+    <div class="skillbox">
+ifdef::nolinks[]
+<strong>{skill_architecture_title}</strong>
+endif::[]
+ifndef::nolinks[]
+        <a href="{basedir}/articles/lists/skill-Software-Architektur.html"><strong>{skill_architecture_title}</strong></a>
+endif::[]
+<br>
+        {skill_architecture_1}<br>
+        {skill_architecture_2}<br>
+        {skill_architecture_3}<br>
+    </div>
+    <div class="skillbox">
+        <strong>{skill_methods_title}</strong><br>
+        {skill_methods_1}<br>
+        {skill_methods_2}<br>
+ifdef::nolinks[]
+{skill_methods_docascode}
+endif::[]
+ifndef::nolinks[]
+        <a href="{basedir}/articles/lists/skill-Docs-as-Code.html">{skill_methods_docascode}</a>
+endif::[]
+        {skill_methods_4}<br>
+        {skill_methods_5}
+    </div>
+</div>
+
+<div class="skillrow {compact-class}">
+    <div class="skillbox">
+        <strong>{skill_platform_title}</strong><br>
+        {skill_platform_1}<br>
+        {skill_platform_2}<br>
+ifdef::nolinks[]
+{skill_platform_cicd}
+endif::[]
+ifndef::nolinks[]
+        <a href="{basedir}/articles/lists/skill-CI-CD-Pipelines.html">{skill_platform_cicd}</a>
+endif::[]
+        {skill_platform_4}<br>
+    </div>
+</div>
+
+<div class="skillrow {compact-class}">
+    <div class="skillbox">
+        <strong>{skill_branches_title}</strong><br>
+        {skill_branches_1}
+    </div>
+</div>
+++++

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -42,3 +42,9 @@
 :ui_author_prefix: Autor:
 :ui_language_flag_de: 🇦🇹
 :ui_language_flag_en: 🇬🇧
+:ui_article_list_back: Zurück zur Artikelübersicht
+:ui_article_list_show_all: Alle Artikel anzeigen
+:ui_article_list_recent: Die zuletzt veröffentlichten Artikel:
+:ui_article_list_languages: Artikel nach Sprache
+:ui_articles_in_de: Deutsche Artikel
+:ui_articles_in_en: Englische Artikel

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -45,3 +45,4 @@
 :ui_article_list_back: Zurück zur Artikelübersicht
 :ui_article_list_show_all: Alle Artikel anzeigen
 :ui_article_list_recent: Die zuletzt veröffentlichten Artikel:
+:ui_article_list_other_languages: Diese Übersicht zeigt deutschsprachige Artikel. Es gibt auch Artikel auf %languages%.

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -40,3 +40,5 @@
 :ui_cv_nav_projects: Projekte
 :ui_cv_nav_education: Weiterbildung
 :ui_author_prefix: Autor:
+:ui_language_flag_de: 🇦🇹
+:ui_language_flag_en: 🇬🇧

--- a/src-content/profile/includes/i18n/ui-de.adoc
+++ b/src-content/profile/includes/i18n/ui-de.adoc
@@ -45,6 +45,3 @@
 :ui_article_list_back: Zurück zur Artikelübersicht
 :ui_article_list_show_all: Alle Artikel anzeigen
 :ui_article_list_recent: Die zuletzt veröffentlichten Artikel:
-:ui_article_list_languages: Artikel nach Sprache
-:ui_articles_in_de: Deutsche Artikel
-:ui_articles_in_en: Englische Artikel

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -45,3 +45,4 @@
 :ui_article_list_back: Back to the article overview
 :ui_article_list_show_all: Show all articles
 :ui_article_list_recent: The most recently published articles:
+:ui_article_list_other_languages: This overview lists English-language articles. There are also articles in %languages%.

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -42,3 +42,9 @@
 :ui_author_prefix: Author:
 :ui_language_flag_de: 🇦🇹
 :ui_language_flag_en: 🇬🇧
+:ui_article_list_back: Back to the article overview
+:ui_article_list_show_all: Show all articles
+:ui_article_list_recent: The most recently published articles:
+:ui_article_list_languages: Articles by language
+:ui_articles_in_de: German articles
+:ui_articles_in_en: English articles

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -45,6 +45,3 @@
 :ui_article_list_back: Back to the article overview
 :ui_article_list_show_all: Show all articles
 :ui_article_list_recent: The most recently published articles:
-:ui_article_list_languages: Articles by language
-:ui_articles_in_de: German articles
-:ui_articles_in_en: English articles

--- a/src-content/profile/includes/i18n/ui-en.adoc
+++ b/src-content/profile/includes/i18n/ui-en.adoc
@@ -40,3 +40,5 @@
 :ui_cv_nav_projects: Projects
 :ui_cv_nav_education: Professional development
 :ui_author_prefix: Author:
+:ui_language_flag_de: 🇦🇹
+:ui_language_flag_en: 🇬🇧

--- a/src-content/profile/includes/menue.adoc
+++ b/src-content/profile/includes/menue.adoc
@@ -8,6 +8,7 @@
 
 <nav id="mainnav" class="mainnav" data-active="{active}">
     <ul>
+include::{docfile}/../generated/{docname}-langswitch.adoc[opts=optional]
         <li>
             <a data-nav="home" href="{url_index}">{ui_nav_home}{url_index_marker}</a>
         </li>
@@ -37,7 +38,6 @@ endif::[]
 </div>
 <div class="nav-overlay"></div>
 </nav>
-include::{docfile}/../generated/{docname}-langswitch.adoc[opts=optional]
 
 <script type="text/javascript" src="{basedir}/stylesheet/navigation.js"></script>
 ++++

--- a/src-content/profile/site/articles/articles.adoc
+++ b/src-content/profile/site/articles/articles.adoc
@@ -9,8 +9,6 @@ endif::[]
 :active: articles
 include::{includesdir}/docheader.adoc[]
 
-include::{docfile}/../generated/lists/languages.adoc[opts=optional]
-
 [.article-list-intro]
 {ui_article_list_recent}
 

--- a/src-content/profile/site/articles/assets/doc-as-code/doc-influences-en.puml
+++ b/src-content/profile/site/articles/assets/doc-as-code/doc-influences-en.puml
@@ -1,0 +1,30 @@
+@startmindmap
+skinparam backgroundColor transparent
+skinparam shadowing false
+
+* Documentation
+-- Stakeholders
+--- Developers
+--- Product Owner
+--- Project Management
+--- External Service Providers
+** Architecture & Code
+*** Architecture Decisions
+*** Code Structure
+*** Quality Requirements
+** Development Process
+*** Reviews
+*** Versioning
+*** Continuous Integration
+-- Delivery
+--- Website
+--- PDF
+--- Wiki
+--- Customer Documentation
+** Principles
+*** Docs-as-Code
+*** DRY
+*** YAGNI
+*** Structure (e.g. arc42)
+
+@endmindmap

--- a/src-content/profile/site/en/articles/articles.adoc
+++ b/src-content/profile/site/en/articles/articles.adoc
@@ -10,8 +10,6 @@ endif::[]
 :active: articles
 include::{includesdir}/docheader.adoc[]
 
-include::{docfile}/../generated/lists/languages.adoc[opts=optional]
-
 [.article-list-intro]
 {ui_article_list_recent}
 

--- a/src-content/profile/site/en/articles/articles.adoc
+++ b/src-content/profile/site/en/articles/articles.adoc
@@ -1,10 +1,11 @@
-= Artikel
+= Articles
+:lang: en
 include::{includesdir}/../../revinfo.adoc[]
 :revdate!:
 :revnumber!:
 :revremark!:
 ifdef::buildsite[]
-:basedir: ..
+:basedir: ../..
 endif::[]
 :active: articles
 include::{includesdir}/docheader.adoc[]

--- a/src-content/profile/site/en/articles/documentation/doc-as-code.adoc
+++ b/src-content/profile/site/en/articles/documentation/doc-as-code.adoc
@@ -1,0 +1,235 @@
+= Documentation as Code
+:lang: en
+ifdef::buildsite[]
+:basedir: ../../..
+endif::[]
+include::{includesdir}/../../revinfo.adoc[]
+:author: Dieter Baier
+:author_page: index.html
+:revremark: How documentation can stay stable AND: 'Doc as Code' is not the same as 'Code as Doc'
+:revdate: 04/2026
+:revnumber: 1.1
+:active: articles
+include::{includesdir}/docheader.adoc[]
+
+ifeval::["{type}" != "readme"]
+include::{docfile}/../generated/{docname}-tags.adoc[opts=optional]
+// Generated translation provenance; empty unless the article is a translation.
+include::{docfile}/../generated/{docname}-translation.adoc[opts=optional]
+endif::[]
+
+:include_next_articles_variante1: false
+:include_next_articles_variante2: false
+
+[.highlight.info]
+--
+Docs-as-Code does not mean that code replaces documentation. Why would it? It would have to be called Code-as-Doc.
+
+It means treating documentation with the same principles as software: structured, versioned, automated and close to the code.
+
+This article explains why classic documentation so often fails, and how a Docs-as-Code approach can help keep it current and usable over time.
+--
+
+toc::[]
+
+== Two myths about documentation
+
+[quote, Developers]
+____
+My code is the documentation
+____
+
+Do you know this claim?
+
+I know it very well and like to use it myself. But it only holds under the following conditions:
+
+* The code is written according to https://{lang}.wikipedia.org/wiki/Clean_Code[clean code principles^], and thanks to clear, unambiguous naming of functions, variables and interfaces, to the _Single Responsibility Principle_ and to other _best practices_, you really can tell from the code itself what it does and why
+* The system is simple enough that no additional architecture documentation is needed (usually a false assumption!)
+* The code is accessible to all stakeholders, and all stakeholders can read code
+* ...
+
+Fundamentally the claim is simply wrong, because the code can be no more than one part of a software system's documentation. If it really is written cleanly, though, it can certainly be part of it.
+
+If you want to build software seriously and professionally, there is no way around documentation alongside the code.
+
+[quot, Developers]
+____
+Documentation is out of date the moment it is written
+____
+
+Yes, that is true - if it is done _wrongly_.
+
+== Three central questions about documentation
+
+First you have to ask *WHAT* should be documented, second *HOW*, and third *WHY* you want to document at all.
+
+Depending on the environment, the requirements can differ considerably. Public sector projects often demand extensive documentation that you simply cannot avoid. Quite simply, _because that is how it is_. Systems where human lives may be at stake will certainly require different documentation from an administrative application.
+
+Either way: as soon as you have to build a system made of several building blocks, you will think about its architecture - and that belongs in documentation. And if you do it _properly_, architecture always comes into being before the code.
+
+[.highlight.info]
+--
+These days, and thankfully, architecture does not emerge _upfront_. Good architecture is evolutionary and grows with the requirements. Even so, a design always precedes the code, and there are always reasons why code is written (business requirements, quality requirements, and so on). All of that belongs in documentation.
+--
+
+So from the perspective of a software developer and/or software architect, the *WHAT* is answered at the very least by documenting the architecture. What that documentation should look like is individual and can differ from project to project. Out of convenience I stick to proven _best practices_ developed by experts, which is why I follow the https://arc42.org/[arc42 structure^] for architecture documentation. But that is not what this article is about.
+
+So let us turn to *WHY* I should document anything if the code is the real truth anyway.
+
+My immediate answer would be: not every stakeholder can or wants to read code. Project managers (where they exist), or product owners, may well have access to the code, but they have a very different view of the software they are responsible for.
+
+Documentation therefore has to satisfy more abstract, or simply different, perspectives. Architecture documentation focuses on _why_ the software should be written the way it - hopefully - was written (making sure of that is a different discipline within the software development process). It documents various requirements and connects them to strategies and decisions that should ultimately be reflected in the code.
+
+But *HOW* should you document so that the team actually maintains it and keeps it current?
+
+Well, my experience says there should be as few _medium switches_ as possible, so that developers document too - ideally even willingly. Which means: *the closer to the code, the better*.
+
+I therefore try to write all documentation in ASCII format (as the code is) and to store it as close to the code as possible. Where it is possible and sensible, even in the same source repository.
+
+[.highlight.info]
+--
+If I do not have to go looking for where the documentation lives, but get it together with my code, everything is in one place and I can switch between documenting and coding without a break in media.
+
+It also makes it more likely that code and documentation do not drift too far apart. The development process can ensure this more easily as well, because it only has to deal with a single medium.
+--
+
+*Is that already _Docs-as-Code_?*
+
+*NO.*
+
+== What does Docs-as-Code really mean?
+
+Neither the storage location nor the medium is what decides whether something is _Docs-as-Code_ - even though some media are certainly better suited to really living _Docs-as-Code_ than others.
+
+But I can live _Docs-as-Code_ in a Git repository just as well as in Confluence or a similar platform.
+
+[.highlight.info]
+--
+*Docs-as-Code* means, to me, that I do not merely write text and insert pictures, but that I maintain the documentation exactly the way I maintain my code.
+--
+
+That is, I try to keep a *recognisable structure*. I try to honour the *Single Responsibility Principle* in documentation too. And I try to *avoid duplication* and to write nothing that is not needed (*YAGNI*).
+
+One further, very important aspect also helps me decide which medium to use (sadly this is not possible in many client projects, even though I do try to influence it): *_write once, deliver anywhere_*. In the context of documentation this is, in my view, often underestimated - but it becomes absolutely essential at the latest when I have to deliver my documentation, or make it available to different stakeholders from different departments or even different companies.
+
+So it has to be possible for me to write my documentation once and then present it as a website or send it as a PDF, for example. And the quality should not really differ between the two (the browser's print function will not normally produce a satisfying result).
+
+On top of that come the *different views*. I have to be able to prepare my documentation so that, depending on the requirement, it also leaves things out. For instance, you may not want department names to appear in the PDF you send to an external service provider - but you very much do want them in the internal company wiki where the documentation lives. Perhaps even with a direct link into the department intranet, which you would have no access to _from outside_.
+
+So a number of different forces act on documentation:
+
+plantuml::{includesdir}/../site/articles/assets/doc-as-code/doc-influences-en.puml[format=svg, alt="Forces acting on documentation",width=100%]
+
+[.highlight.info]
+--
+Documentation does not come into being in a vacuum. It is shaped by technical, organisational and process-related factors.
+
+Docs-as-Code therefore does not only mean picking a particular tool or format, but deliberately translating those forces into structured, maintainable documentation.
+--
+
+To achieve all of that, real code has to be written in the documentation around the actual documentation. Usually these are macros interpreted while the output format is generated. But pre-processors may be needed as well, which may first have to scan the documentation in order to generate additional artifacts.
+
+So anyone who takes documentation seriously, and holds their software (and therefore their documentation) to a certain standard of quality, will not get around thinking about it at the level of a software developer.
+
+This very site can serve as a direct example. It really only presents static content (much like documentation). But it represents me in different views. It also contains my link:{url_cv}[CV{url_cv_marker}], for instance. Besides the fact that the CV holds information that can also be found on the website, I want to present the CV both as a website and as a directly downloadable PDF. The CV downloaded straight from the website should not, however, contain personal data such as an address or a telephone number. For that case I want to be able to generate a different PDF on demand - from the same content, but with additional material.
+
+This site is written in ASCIIDOC. Accordingly, there are macros that help me decide which content is shown when, and how.
+
+[source,asciidoc]
+----
+\ifeval::["{backend}" == "pdf"]
+=== Skills
+
+\include::{includesdir}/skills/skills_matrix.adoc[]
+\
+'''
+\endif::[]
+----
+
+Here my link:{url_architecture_toolkit}[skills matrix{url_architecture_toolkit_marker}] should only be embedded when the output format is PDF.
+
+Elsewhere the matrix is only embedded when the output format is HTML:
+
+[source,asciidoc]
+----
+\ifeval::["{backend}" == "html5"]
+\include::{includesdir}/skills/skills_matrix.adoc[]
+\endif::[]
+----
+
+You can see it: different places (_views_), same document being embedded.
+
+And since I can present the matrix a little more _fancily_ on the website than in the PDF, I decide once more within the document itself which form should be embedded.
+
+[source,asciidoc]
+----
+\ifeval::["{backend}" == "html5"]
+\include::./skills_matrix_site.adoc[]
+\endif::[]
+
+\ifeval::["{backend}" == "pdf"]
+\include::./skills_matrix_pdf.adoc[]
+\endif::[]
+----
+
+So: *different audience, different presentation*.
+
+== What does a typical Docs-as-Code pipeline look like?
+
+The pipeline for documentation can of course differ in its details. That depends heavily on the environment. The following picture shows, as an example, the pipeline for this website:
+
+plantuml::{includesdir}/../site/articles/assets/doc-as-code/doc-pipeline.puml[format=svg, alt="Documentation build pipeline",width=100%]
+
+The _build system_ is visible as the central component. This website is built with `Gradle` and `asciidoctor`. That can of course vary. There could be other frameworks around or in front of `asciidoctor`, such as the https://doctoolchain.org[docToolchain^]. The idea, however, is always the same:
+
+* *Write the documentation* as _code_
+* Use interpreters of your documentation to
+* *generate* different *output formats* of that documentation
+
+== Key takeaways
+
+[.callout]
+--
+* **Code alone is not documentation.**
+Good software also needs context, decisions and architecture.
+
+* **Documentation only works without a break in media.**
+The closer it sits to the code and to the development process, the more likely it stays current.
+
+* **Docs-as-Code is not a tool - it is a way of working.**
+Documentation is structured, versioned, automated and maintained like code.
+
+* **Automation makes documentation sustainable.**
+A build pipeline makes it possible to generate different output formats from the same sources.
+--
+
+== Conclusion
+
+Documentation rarely fails because people do not want to document.
+It usually fails because the process does not fit the way they work day to day.
+
+The *Docs-as-Code* approach tries to solve exactly that problem:
+documentation is written where the code comes into being, with the same tools, the same principles and the same automation.
+
+That way documentation does not become an annoying extra task - it becomes a natural part of software development.
+
+[quote]
+____
+Documentation is not a by-product of software development - it is part of it.
+
+The *code* shows *what* a system does.
+*Documentation* explains *why*.
+____
+
+[.highlight.info]
+--
+These thoughts led me to put together a toolkit that gives me the tools to _live_ my documentation philosophy simply and consistently when writing my own documentation.
+
+You can find that toolkit at https://github.com/docs-as-code-toolkit[^] as an open source project.
+--
+
+// Generated article navigation (previous/next and related articles); website only.
+ifeval::["{type}" != "readme"]
+include::{docfile}/../generated/{docname}-navigation.adoc[opts=optional]
+include::{docfile}/../generated/{docname}-comments.adoc[opts=optional]
+endif::[]

--- a/src-content/profile/site/en/articles/documentation/doc-as-code.profile.yaml
+++ b/src-content/profile/site/en/articles/documentation/doc-as-code.profile.yaml
@@ -1,0 +1,27 @@
+  id: ART-003-doc-as-code-en
+  type: Article
+  title: "Documentation as Code"
+  status: published
+  owner: "Dieter Baier"
+  created: '2026-08-02'
+  published: '2026-08-02'
+  reviewed: false
+  generated: false
+  language: en
+  translation_of: ART-003-doc-as-code
+  translation_source_digest: bb768910d2861c86a95a7311ec5ad75e265079e095aa181718c334a1a0fead62
+  audience:
+    - employers
+    - clients
+    - technical-community
+  channels:
+    - website
+  summary: "Article explaining Docs-as-Code as a documentation discipline."
+  summary_en: "What Docs-as-Code means as a documentation discipline, and why documentation should be maintained, versioned and generated like source code."
+  source: src-content/profile/site/en/articles/documentation/doc-as-code.adoc
+  tags:
+    - docs-as-code
+  skills:
+    - Docs-as-Code
+  relations: []
+  metadata_version: '1.0'

--- a/src-content/profile/site/en/index.adoc
+++ b/src-content/profile/site/en/index.adoc
@@ -20,6 +20,10 @@ include::{includesdir}/docheader.adoc[]
 
 [.highlight]
 --
-This English section of the site is being built up gradually. Pages that are not
-translated yet are linked in German.
+include::{includesdir}/i18n/{lang}/profile/profile.adoc[]
+include::{includesdir}/i18n/{lang}/profile/profile_personal.adoc[]
 --
+
+include::{includesdir}/i18n/{lang}/profile/about_me_citations.adoc[]
+
+link:{url_cv}[Curriculum Vitae{url_cv_marker}, role="fingerPointsTo"]

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -702,7 +702,7 @@ footer p {
 .mainnav ul .language-switch {
     display: flex;
     align-items: center;
-    margin-right: -1.4rem;
+    gap: 0.5rem;
     font-size: 1.15rem;
     line-height: 1;
 }
@@ -722,7 +722,7 @@ footer p {
     border-bottom: 2px solid #3a7bd5;
 }
 
-.mainnav ul .language-switch-current span {
+.mainnav ul .language-switch .language-switch-current {
     filter: none;
     opacity: 1;
     cursor: default;
@@ -803,8 +803,16 @@ footer p {
     }
 
     .mainnav ul {
-        flex-direction: column;
         position: relative;
+    }
+
+    /* The top row stays on one line. It carries the language flags next to Home,
+       and the drawer list below has its own rule that stacks its entries. */
+    .mainnav > ul:first-child {
+        flex-direction: row;
+        align-items: center;
+        flex-wrap: nowrap;
+        gap: 1rem;
     }
 
     .mainnav {

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -728,6 +728,20 @@ footer p {
     cursor: default;
 }
 
+/* Article listings per language: the sub-navigation above a listing offers the
+   same listing in the other languages that have articles. */
+.language-nav {
+    margin-bottom: 1.5rem;
+}
+
+.language-nav .language-nav-current {
+    font-weight: 600;
+    color: var(--text-color);
+    border-bottom: 2px solid #3a7bd5;
+    padding: 0.4rem 0;
+    cursor: default;
+}
+
 .cvcontactlanguage {
     margin-top: 1rem;
     display: flex;

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -728,6 +728,18 @@ footer p {
     cursor: default;
 }
 
+/* Shown above a listing that promises a complete set, when other languages
+   publish articles for it too. A statement, not a control: the language
+   switcher in the menu stays the only way to change language. */
+.article-list-languages {
+    margin: 0 0 1.5rem;
+    padding: 0.6rem 0.9rem;
+    background: var(--bg-surface);
+    border-left: 3px solid var(--box-border-strong);
+    color: var(--text-color-subtle);
+    font-size: 0.95rem;
+}
+
 .cvcontactlanguage {
     margin-top: 1rem;
     display: flex;

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -732,7 +732,7 @@ footer p {
    publish articles for it too. A statement, not a control: the language
    switcher in the menu stays the only way to change language. */
 .article-list-languages {
-    margin: 0 0 1.5rem;
+    margin: 1.5rem 0;
     padding: 0.6rem 0.9rem;
     background: var(--bg-surface);
     border-left: 3px solid var(--box-border-strong);

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -728,20 +728,6 @@ footer p {
     cursor: default;
 }
 
-/* Article listings per language: the sub-navigation above a listing offers the
-   same listing in the other languages that have articles. */
-.language-nav {
-    margin-bottom: 1.5rem;
-}
-
-.language-nav .language-nav-current {
-    font-weight: 600;
-    color: var(--text-color);
-    border-bottom: 2px solid #3a7bd5;
-    padding: 0.4rem 0;
-    cursor: default;
-}
-
 .cvcontactlanguage {
     margin-top: 1rem;
     display: flex;

--- a/src-content/theme/style.css
+++ b/src-content/theme/style.css
@@ -696,6 +696,38 @@ footer p {
     border-bottom: 2px solid #3a7bd5;
 }
 
+/* Language switcher: flags sit ahead of the first menu entry. They carry the
+   language name on title/aria-label, because a flag names a country, not a
+   language, and is no accessible name on its own. */
+.mainnav ul .language-switch {
+    display: flex;
+    align-items: center;
+    margin-right: -1.4rem;
+    font-size: 1.15rem;
+    line-height: 1;
+}
+
+.mainnav ul .language-switch a,
+.mainnav ul .language-switch span {
+    padding: 0.4rem 0;
+    border-bottom: 2px solid transparent;
+    filter: grayscale(0.55);
+    opacity: 0.75;
+    transition: all 0.2s ease;
+}
+
+.mainnav ul .language-switch a:hover {
+    filter: none;
+    opacity: 1;
+    border-bottom: 2px solid #3a7bd5;
+}
+
+.mainnav ul .language-switch-current span {
+    filter: none;
+    opacity: 1;
+    cursor: default;
+}
+
 .cvcontactlanguage {
     margin-top: 1rem;
     display: flex;

--- a/test/profile_language_alternates_test.rb
+++ b/test/profile_language_alternates_test.rb
@@ -63,10 +63,13 @@ class ProfileLanguageAlternatesTest < Minitest::Test
       german = switcher(root, 'site/generated/index-langswitch.adoc')
       english = switcher(root, 'site/en/generated/index-langswitch.adoc')
 
-      assert_includes german, '<span class="language-switch-current" lang="de">'
-      assert_match(%r{<a href="[^"]*en/index\.html" lang="en"}, german)
-      assert_includes english, '<span class="language-switch-current" lang="en">'
-      assert_match(%r{<a href="[^"]*index\.html" lang="de"}, english)
+      # Rendered as menu list items: a flag as the visible label, the language
+      # name on title and aria-label, because a flag is no accessible name.
+      assert_includes german, '<li class="language-switch language-switch-current">'
+      assert_includes german, 'title="{ui_language_name_de}"'
+      assert_match(%r{<a href="[^"]*en/index\.html" lang="en"[^>]*>\{ui_language_flag_en\}</a>}, german)
+      assert_includes english, '<li class="language-switch language-switch-current">'
+      assert_match(%r{<a href="[^"]*index\.html" lang="de"[^>]*>\{ui_language_flag_de\}</a>}, english)
     end
   end
 

--- a/test/profile_language_alternates_test.rb
+++ b/test/profile_language_alternates_test.rb
@@ -65,11 +65,15 @@ class ProfileLanguageAlternatesTest < Minitest::Test
 
       # Rendered as menu list items: a flag as the visible label, the language
       # name on title and aria-label, because a flag is no accessible name.
-      assert_includes german, '<li class="language-switch language-switch-current">'
-      assert_includes german, 'title="{ui_language_name_de}"'
+      # One list item holds every language, so the menu row's single gap cannot
+      # push the flags apart. A flag is the visible label only; the language name
+      # stays on title and aria-label, because a flag is no accessible name.
+      assert_includes german, '<li class="language-switch">'
+      assert_includes german, '<span class="language-switch-current" lang="de" title="{ui_language_name_de}"'
       assert_match(%r{<a href="[^"]*en/index\.html" lang="en"[^>]*>\{ui_language_flag_en\}</a>}, german)
-      assert_includes english, '<li class="language-switch language-switch-current">'
+      assert_includes english, '<span class="language-switch-current" lang="en"'
       assert_match(%r{<a href="[^"]*index\.html" lang="de"[^>]*>\{ui_language_flag_de\}</a>}, english)
+      assert_equal 1, german.scan('<li class="language-switch">').length
     end
   end
 

--- a/test/profile_language_alternates_test.rb
+++ b/test/profile_language_alternates_test.rb
@@ -77,6 +77,46 @@ class ProfileLanguageAlternatesTest < Minitest::Test
     end
   end
 
+  # The listings are generated pages without metadata. Basing the switcher on
+  # artifacts left exactly those pages without one, which is what made a second,
+  # differently shaped switcher look necessary in the first place.
+  def test_generated_listing_pages_offer_the_switcher_as_well
+    # Given: published articles in two languages
+    Dir.mktmpdir('profile-alternates-listing-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'includes/i18n').mkpath
+      %w[de en].each do |language|
+        (root + "includes/i18n/ui-#{language}.adoc").write(
+          ":ui_article_list_all: All\n:ui_article_list_tag_prefix: Tag:\n:ui_article_list_skill_prefix: Skill:\n"
+        )
+      end
+
+      [['ART-001-de', 'site/articles', 'de'], ['ART-002-en', 'site/en/articles', 'en']].each do |id, rel_dir, language|
+        (root + rel_dir).mkpath
+        source = "#{rel_dir}/entry.adoc"
+        (root + source).write("= entry\n")
+        (root + "#{rel_dir}/entry.profile.yaml").write({
+          'id' => id, 'type' => 'Article', 'title' => id, 'status' => 'published', 'owner' => 'Test Owner',
+          'created' => '2026-01-01', 'language' => language, 'source' => source
+        }.to_yaml)
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      validator.generate_article_lists(artifacts)
+
+      # When: the language switchers are generated
+      validator.generate_language_switchers(artifacts)
+
+      # Then: the generated article listings of each language offer the switcher too
+      german = switcher(root, 'site/articles/generated/pages/generated/all-langswitch.adoc')
+      english = switcher(root, 'site/en/articles/generated/pages/generated/all-langswitch.adoc')
+
+      assert_match(%r{<a href="\.\./\.\./en/articles/lists/all\.html"}, german)
+      assert_match(%r{<a href="\.\./\.\./\.\./articles/lists/all\.html"}, english)
+    end
+  end
+
   def test_page_without_a_translation_offers_no_language_switcher
     # Given: a page that exists in the default language only
     with_pages([{ id: 'PAGE-001-index', slug: 'index', dir: 'site', language: 'de' }]) do |validator, artifacts, root|

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -559,6 +559,25 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
+  # A translation shares its original's tags, so without excluding the whole
+  # translation group the language-preferring swap turns a variant of the article
+  # into a recommendation to read the article you are already on.
+  def test_an_article_is_not_recommended_as_related_to_its_own_translation
+    with_artifacts(
+      [
+        { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+        { id: 'ART-001-en', slug: 'first', dir: 'site/en/articles', language: 'en', tags: %w[architecture],
+          translation_of: 'ART-001-de' }
+      ],
+      ui_terms: BILINGUAL_UI_TERMS
+    ) do |validator, root, artifacts|
+      validator.generate_article_navigation(artifacts)
+
+      assert_empty (root + 'site/articles/generated/first-navigation.adoc').read
+      assert_empty (root + 'site/en/articles/generated/first-navigation.adoc').read
+    end
+  end
+
   # Each language variant is its own artifact, so its comment thread and its
   # allowlist entry follow from its own ID without any extra rule.
   def test_comment_threads_are_separate_per_language_variant

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -502,7 +502,9 @@ class ProfileLanguageTest < Minitest::Test
       # Each listing is titled in its own language and lists only its own articles.
       assert_includes german, '= Alle Artikel'
       assert_includes german, 'first.html'
-      refute_includes german, 'en/articles'
+      # Only its own articles are listed. The language navigation does link to
+      # the English listing, so the check is on the article cards themselves.
+      assert_equal 1, german.scan('article-card-title').length
 
       assert_includes english, '= All articles'
       assert_includes english, 'first.html'

--- a/test/profile_listings_test.rb
+++ b/test/profile_listings_test.rb
@@ -313,4 +313,101 @@ class ProfileListingsTest < Minitest::Test
       refute_equal '', first.first
     end
   end
+
+  # --- Language variants of the listings -------------------------------------
+
+  # Builds articles in two languages and returns the validator plus the tree.
+  def with_multilingual_articles(articles)
+    Dir.mktmpdir('profile-list-language-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'includes/i18n').mkpath
+      %w[de en].each do |language|
+        (root + "includes/i18n/ui-#{language}.adoc").write(
+          ":ui_article_list_all: All\n" \
+          ":ui_article_list_tag_prefix: Tag:\n" \
+          ":ui_article_list_skill_prefix: Skill:\n"
+        )
+      end
+
+      articles.each do |article|
+        rel_dir = article.fetch(:dir)
+        slug = article.fetch(:slug)
+        (root + rel_dir).mkpath
+        source = "#{rel_dir}/#{slug}.adoc"
+        (root + source).write("= #{slug}\n")
+        metadata = {
+          'id' => article.fetch(:id), 'type' => 'Article', 'title' => slug, 'status' => 'published',
+          'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => article.fetch(:language),
+          'source' => source, 'tags' => article.fetch(:tags, [])
+        }
+        (root + "#{rel_dir}/#{slug}.profile.yaml").write(metadata.to_yaml)
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      validator.generate_article_lists(artifacts)
+      yield(root)
+    end
+  end
+
+  BILINGUAL = [
+    { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[shared] },
+    { id: 'ART-002-en', slug: 'second', dir: 'site/en/articles', language: 'en', tags: %w[shared] }
+  ].freeze
+
+  def test_article_listings_are_built_per_language
+    # Given: published articles in two languages
+    with_multilingual_articles(BILINGUAL) do |root|
+      # When: the article listings are generated (done by the helper)
+      # Then: each language gets its own listing pages containing only its own articles
+      german = (root + 'site/articles/generated/pages/all.adoc').read
+      english = (root + 'site/en/articles/generated/pages/all.adoc').read
+
+      assert_includes german, 'first.html'
+      refute_includes german, 'second.html'
+      assert_includes english, 'second.html'
+      refute_includes english, 'first.html'
+    end
+  end
+
+  def test_listing_offers_the_same_listing_in_the_other_languages
+    # Given: published articles in two languages
+    with_multilingual_articles(BILINGUAL) do |root|
+      # When: the article listings are generated (done by the helper)
+      # Then: each listing page links to the same listing in the other language
+      german = (root + 'site/articles/generated/pages/all.adoc').read
+      english = (root + 'site/en/articles/generated/pages/all.adoc').read
+
+      assert_includes german, '<li><a href="{basedir}/en/articles/lists/all.html">{ui_articles_in_en}</a></li>'
+      assert_includes german, '{ui_articles_in_de}</span>'
+      assert_includes english, '<li><a href="{basedir}/articles/lists/all.html">{ui_articles_in_de}</a></li>'
+      assert_includes english, '{ui_articles_in_en}</span>'
+    end
+  end
+
+  def test_a_language_is_only_offered_for_a_tag_it_actually_uses
+    # Given: a tag used by articles in one language only
+    articles = [
+      { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[germanonly] },
+      { id: 'ART-002-en', slug: 'second', dir: 'site/en/articles', language: 'en', tags: %w[englishonly] }
+    ]
+
+    with_multilingual_articles(articles) do |root|
+      # When: the article listings are generated (done by the helper)
+      # Then: that tag page offers no link to the language without such articles
+      german_tag = (root + 'site/articles/generated/pages/tag-germanonly.adoc').read
+      refute_includes german_tag, '{ui_articles_in_en}'
+      refute_includes german_tag, 'language-nav'
+    end
+  end
+
+  def test_listing_pages_of_a_language_subtree_resolve_their_assets
+    # Given: published articles in a language below the site root
+    with_multilingual_articles(BILINGUAL) do |root|
+      # When: the article listings are generated (done by the helper)
+      # Then: their pages point back to the site root from their own depth
+      assert_includes (root + 'site/articles/generated/pages/all.adoc').read, ":basedir: ../..\n"
+      assert_includes (root + 'site/en/articles/generated/pages/all.adoc').read, ":basedir: ../../..\n"
+    end
+  end
 end

--- a/test/profile_listings_test.rb
+++ b/test/profile_listings_test.rb
@@ -321,11 +321,17 @@ class ProfileListingsTest < Minitest::Test
     Dir.mktmpdir('profile-list-language-test') do |dir|
       root = Pathname.new(dir)
       (root + 'includes/i18n').mkpath
-      %w[de en].each do |language|
+      {
+        'de' => 'Es gibt auch Artikel auf %languages%.',
+        'en' => 'There are also articles in %languages%.'
+      }.each do |language, note|
         (root + "includes/i18n/ui-#{language}.adoc").write(
           ":ui_article_list_all: All\n" \
           ":ui_article_list_tag_prefix: Tag:\n" \
-          ":ui_article_list_skill_prefix: Skill:\n"
+          ":ui_article_list_skill_prefix: Skill:\n" \
+          ":ui_language_name_de: Deutsch\n" \
+          ":ui_language_name_en: English\n" \
+          ":ui_article_list_other_languages: #{note}\n"
         )
       end
 
@@ -377,6 +383,38 @@ class ProfileListingsTest < Minitest::Test
       # Then: their pages point back to the site root from their own depth
       assert_includes (root + 'site/articles/generated/pages/all.adoc').read, ":basedir: ../..\n"
       assert_includes (root + 'site/en/articles/generated/pages/all.adoc').read, ":basedir: ../../..\n"
+    end
+  end
+
+  def test_listing_names_the_other_languages_that_publish_articles
+    # Given: published articles in two languages
+    with_multilingual_articles(BILINGUAL) do |root|
+      # When: the article listings are generated (done by the helper)
+      # Then: each complete listing states that articles exist in the other language
+      german = (root + 'site/articles/generated/pages/all.adoc').read
+      english = (root + 'site/en/articles/generated/pages/all.adoc').read
+
+      assert_includes german, 'article-list-languages'
+      assert_includes german, 'auch Artikel auf English'
+      assert_includes english, 'also articles in Deutsch'
+      # No count is claimed, so the sentence cannot go wrong when a language has fewer.
+      refute_match(/\b\d+\b/, german[/<p class="article-list-languages">[^<]*/])
+    end
+  end
+
+  def test_a_listing_of_a_tag_used_by_one_language_only_names_no_other_language
+    # Given: a tag used by articles in one language only
+    articles = [
+      { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[germanonly] },
+      { id: 'ART-002-en', slug: 'second', dir: 'site/en/articles', language: 'en', tags: %w[englishonly] }
+    ]
+
+    with_multilingual_articles(articles) do |root|
+      # When: the article listings are generated (done by the helper)
+      # Then: that tag listing states nothing about other languages
+      refute_includes (root + 'site/articles/generated/pages/tag-germanonly.adoc').read, 'article-list-languages'
+      # The complete listing still does, because both languages publish articles.
+      assert_includes (root + 'site/articles/generated/pages/all.adoc').read, 'article-list-languages'
     end
   end
 end

--- a/test/profile_listings_test.rb
+++ b/test/profile_listings_test.rb
@@ -370,37 +370,6 @@ class ProfileListingsTest < Minitest::Test
     end
   end
 
-  def test_listing_offers_the_same_listing_in_the_other_languages
-    # Given: published articles in two languages
-    with_multilingual_articles(BILINGUAL) do |root|
-      # When: the article listings are generated (done by the helper)
-      # Then: each listing page links to the same listing in the other language
-      german = (root + 'site/articles/generated/pages/all.adoc').read
-      english = (root + 'site/en/articles/generated/pages/all.adoc').read
-
-      assert_includes german, '<li><a href="{basedir}/en/articles/lists/all.html">{ui_articles_in_en}</a></li>'
-      assert_includes german, '{ui_articles_in_de}</span>'
-      assert_includes english, '<li><a href="{basedir}/articles/lists/all.html">{ui_articles_in_de}</a></li>'
-      assert_includes english, '{ui_articles_in_en}</span>'
-    end
-  end
-
-  def test_a_language_is_only_offered_for_a_tag_it_actually_uses
-    # Given: a tag used by articles in one language only
-    articles = [
-      { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[germanonly] },
-      { id: 'ART-002-en', slug: 'second', dir: 'site/en/articles', language: 'en', tags: %w[englishonly] }
-    ]
-
-    with_multilingual_articles(articles) do |root|
-      # When: the article listings are generated (done by the helper)
-      # Then: that tag page offers no link to the language without such articles
-      german_tag = (root + 'site/articles/generated/pages/tag-germanonly.adoc').read
-      refute_includes german_tag, '{ui_articles_in_en}'
-      refute_includes german_tag, 'language-nav'
-    end
-  end
-
   def test_listing_pages_of_a_language_subtree_resolve_their_assets
     # Given: published articles in a language below the site root
     with_multilingual_articles(BILINGUAL) do |root|


### PR DESCRIPTION
Closes #57. Final implementation slice of #47.

Translates the home page and the Docs-as-Code article into English and proves the whole chain on real content.

## ⚠️ This is a first draft of your words

The prose is a translation of text you wrote — profile, personal commitment, colleague quotes, and the full 260-line article. I kept your voice and structure, but **please read it as a draft**: register, emphasis and the quotes in particular are yours to judge. The colleague quotes were translated rather than re-invented; if they were originally said in German, you may prefer to leave them German with a note, or to have them re-worded.

## What now works end to end on the English article

| Mechanism | Result |
|---|---|
| Chrome | `Home`, `Articles`, `Curriculum Vitae (de)`, `Legal notice (de)` |
| Provenance note | *"This is a translation of the original article Dokumentation als Code"*, linking to the German page |
| Navigation | *"You might also be interested in"* → `Smarter CI/CD (de)` — the fallback marker on real content |
| Listings | `/en/articles/lists/{all,tag-docs-as-code,skill-Docs-as-Code}.html`, titled *All articles*, *Articles tagged: docs-as-code* |
| Comments | own thread `ART-003-doc-as-code-en`, in the allowlist next to the German ID |
| hreflang | `de`, `en`, `x-default` on both variants |
| Switcher | 🇦🇹 / 🇬🇧 ahead of Home, current language marked |

## Language switcher

Moved into the menu row before Home and rendered as flags:

```html
<li class="language-switch language-switch-current"><span lang="de" title="Deutsch" aria-current="true">🇦🇹</span></li>
<li class="language-switch"><a href="en/index.html" lang="en" hreflang="en" title="Englisch" aria-label="Englisch">🇬🇧</a></li>
```

The flag is the visible label only. The language name stays on `title` and `aria-label`, because a flag names a *country*, not a language — 🇦🇹 for German is a deliberate choice about you, not about the language, and a screen reader would otherwise announce nothing useful. Styling: inactive flag desaturated and slightly transparent, full colour on hover and for the current language.

## Two bugs only real content could surface

**1. Listings of a single-article language landed one directory too deep.** `articles_base_dir` took the common ancestor of the article sources; with one English article that is the article's own subdirectory, so `/en/articles/lists/` was never produced. It now derives the enclosing `articles` directory.

**2. The German article recommended itself.** Its English translation shares its tags, so it entered the related list, and the language-preferring swap from #53 resolved that suggestion back to the German original. Translations of an article are now excluded from its own recommendations — with a test.

## Content added

* `includes/i18n/en/profile/{profile,profile_personal,about_me_citations}.adoc`
* `includes/i18n/en/skills/` — 4 files; only category titles and one skill label are language-dependent, the technology names are proper nouns
* `site/en/index.adoc` — mirrors the German structure
* `site/en/articles/documentation/doc-as-code.adoc` + sidecar with `translation_of` and the recorded digest
* `assets/doc-as-code/doc-influences-en.puml` — the mindmap was German

## A gap worth knowing about

`plantuml::` asset references are **not** covered by the fragment-language check. I noticed the German mindmap by reading the diagram, not because the build complained. A future English page could silently embed a German diagram. Worth a follow-up issue — say the word and I will open one.

## Verification

German output changes only where intended: the switcher on the two pages that now have translations, plus the stylesheet.

```
articles/documentation/doc-as-code.html   (switcher only)
index.html                                (switcher only)
stylesheet/style.css                      (switcher styling)
Only in build/site: en
```

| Suite | Result |
|---|---|
| `profile_language` | 34 runs, 101 assertions, 0 failures |
| `profile_cv_language` | 4 runs, 25 assertions, 0 failures |
| `profile_language_alternates` | 3 runs, 16 assertions, 0 failures |
| `profile_translation` | 7 runs, 27 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 12 runs, 56 assertions, 0 failures |
| `profile_comments` | 7 runs, 60 assertions, 0 failures |
| `site_metadata_injector` | 11 runs, 28 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 0 errors, 1 coverage warning (88 of 95 fragments untranslated — all CV) |
| Architecture validator | 55 artifacts, 0 errors, 0 warnings |

Merging publishes `/en/` with both pages.
