### PR TITLE
issue_65: Bridge the language slices to scenarios

### DIFF
--- a/features/article-comments.feature
+++ b/features/article-comments.feature
@@ -23,7 +23,22 @@ Feature: GitHub-backed article comments
     When the article is rendered for a non-website target
     Then the website-only comment block is omitted
 
-  Scenario: Only published article ids are synchronized
+  Scenario: Only published website article ids are synchronized
     Given published, preview, and non-website articles
     When the deployment allowlist is generated
     Then it contains only article ids eligible for the public website
+
+  # Language variants. Each variant is its own artifact with its own id, so its
+  # discussion is its own too - an English reader should not land in a German
+  # thread.
+
+  Scenario: Comment wording follows the page language
+    Given an article comment block on a page in any language
+    When the comment block is generated
+    Then its wording is left to the page's interface terms and the script carries none
+
+  Scenario: Each language variant has its own comment thread
+    Given an article published in two languages
+    When the comment blocks and the allowlist are generated
+    Then each variant uses its own article id and both ids are synchronized
+

--- a/features/article-navigation.feature
+++ b/features/article-navigation.feature
@@ -86,3 +86,23 @@ Feature: Article navigation
     Given a set of articles with tags and series links
     When the article navigation is generated twice
     Then both generations produce identical navigation files
+
+  # Recommendations across languages. A suggestion is resolved to the reader's
+  # language where that variant exists; one that exists only in the default
+  # language is still offered rather than dropped, and says where it leads.
+
+  Scenario: A recommendation is resolved to the language of the reader
+    Given an article recommended in two languages and a reader on an English article
+    When the article navigation is generated
+    Then the English variant is recommended without a language marker
+
+  Scenario: A recommendation available in one language only names that language
+    Given an article that exists in the default language only
+    When the article navigation is generated
+    Then it is still recommended and marked with the language it leads to
+
+  Scenario: An article is not recommended as related to its own translation
+    Given an article and its translation, which share their tags
+    When the article navigation is generated
+    Then neither variant recommends the other
+

--- a/features/canonical-site-urls.feature
+++ b/features/canonical-site-urls.feature
@@ -33,3 +33,9 @@ Feature: Canonical URLs for the public site
     Given a production site build without a configured base URL
     When public site metadata injection is invoked
     Then the build fails before deployment
+
+  Scenario: Language subtree pages keep their language prefix in the canonical url
+    Given a generated public site whose pages exist below a language prefix
+    When public site metadata is injected
+    Then each variant keeps its own prefix in the canonical URL
+

--- a/features/content-fragment-languages.feature
+++ b/features/content-fragment-languages.feature
@@ -1,0 +1,42 @@
+# Living documentation for the language rule on reusable content fragments.
+#
+# Bridged to: test/profile_language_test.rb (classic Minitest, no native BDD
+# runner in this repository). Each scenario maps to at least one automated test
+# method named after the sanitized scenario title, with Given/When/Then comment
+# anchors inside it.
+#
+# Fragments are the one class that does not fall back. A link leading to a German
+# page is still usable, so it falls back and says so; a German paragraph inside
+# an English page is not, so the build stops instead of producing a page in mixed
+# languages. That is the trade-off ADR-010 records: a page is all-or-nothing,
+# while translation itself can progress fragment by fragment.
+
+Feature: Content fragment languages
+  As a reader of a page in my language
+  I want its body to be in that language throughout
+  So that I never hit a paragraph I cannot read in the middle of a page
+
+  Scenario: A fragment missing in the page language stops the build
+    Given a page including a fragment that exists only in the default language
+    When the profile metadata is validated
+    Then validation reports the fragment, the page and the language
+
+  Scenario: A fragment of another language stops the build
+    Given a page including a fragment of a different language directly
+    When the profile metadata is validated
+    Then validation reports that a page may only include fragments of its own language
+
+  Scenario: A translated fragment is accepted
+    Given a page including a fragment that exists in the page language
+    When the profile metadata is validated
+    Then validation reports no error
+
+  Scenario: Fragments reached through attributes are checked too
+    Given a page whose fragment chain ends in an attribute-driven include
+    When the profile metadata is validated
+    Then validation reports the missing fragment at the end of that chain
+
+  Scenario: Untranslated fragments nobody includes are reported as coverage
+    Given fragments that are not translated and no page including them
+    When the profile metadata is validated
+    Then validation reports the untranslated fragments as a warning without failing

--- a/features/language-chrome.feature
+++ b/features/language-chrome.feature
@@ -1,0 +1,49 @@
+# Living documentation for how a page gets its wording and its page references in
+# the reader's language.
+#
+# Bridged to: test/profile_language_test.rb (classic Minitest, no native BDD
+# runner in this repository). Each scenario maps to at least one automated test
+# method named after the sanitized scenario title, with Given/When/Then comment
+# anchors inside it. Traceability is a reviewer-verifiable convention, not a
+# build-enforced link.
+#
+# Two classes with deliberately opposite rules, decided in ADR-010: a link
+# leading to a page in the default language is still usable, so it falls back and
+# says so. Interface wording has nowhere to say it, so a missing term fails the
+# build instead. Content fragments are the third class and do not fall back at
+# all; they are specified in features/content-fragment-languages.feature.
+
+Feature: Language chrome
+  As a reader of a page in my language
+  I want its wording and its links to follow that language
+  So that the page is coherent and no link leads me nowhere
+
+  Scenario: Interface wording of a language must be complete
+    Given content in a language whose interface terms are missing a key
+    When the profile metadata is validated
+    Then validation reports the missing key and the language
+
+  Scenario: A language that has content must have interface terms
+    Given content in a language that has no interface terms at all
+    When the profile metadata is validated
+    Then validation reports the missing interface terms
+
+  Scenario: Page reference resolves to the same-language page
+    Given a page that exists in the default language and in one other language
+    When the link registries are generated
+    Then the reference of each language resolves to that language's page and carries no marker
+
+  Scenario: Page reference falls back and names the language it leads to
+    Given a page that exists in the default language only
+    When the link registries are generated
+    Then the other language resolves the reference to the default-language page and marks it
+
+  Scenario: A reference no page can satisfy is rejected
+    Given a page referencing a target that no page provides
+    When the profile metadata is validated
+    Then validation reports the unknown page reference
+
+  Scenario: Article chrome takes its wording from the page it lands on
+    Given articles that share a meaningful tag
+    When the per-article includes are generated
+    Then their navigation and comment wording is left to the page's interface terms

--- a/test/article_comments_test.mjs
+++ b/test/article_comments_test.mjs
@@ -134,7 +134,7 @@ test('searches beyond the GitHub result limit remain retryable', async () => {
     assert.equal(button.hidden, false);
 });
 
-test('status wording follows the page language instead of the script', async () => {
+test('comment wording follows the page language', async () => {
     // Given: a page that supplies English interface terms
     const fetch = async () => ({
         ok: true,

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -68,7 +68,7 @@ class ProfileCommentsTest < Minitest::Test
   # The script must stay free of wording so a translated page can supply its own.
   # The block therefore carries the status strings as attribute references, which
   # the page resolves against its interface terms.
-  def test_comment_status_wording_comes_from_the_page_not_the_script
+  def test_comment_wording_follows_the_page_language
     with_article do |validator, artifacts, root|
       validator.generate_article_comment_includes(artifacts)
       generated = (root + 'articles/generated/example-comments.adoc').read

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
-# Validator tests for the language and translation dimension of the profile
-# metamodel.
+# Tests for the language and translation dimension of the profile metamodel.
 #
-# These rules are author-facing: they decide which metadata the build accepts,
-# not what a reader sees. There is therefore no Gherkin feature bridged here,
-# unlike the navigation, listing, and comment generators. Each test builds an
-# isolated temporary profile tree so the real repository is never touched.
+# Two kinds of test live here. The metadata rules are author-facing: they decide
+# which metadata the build accepts, not what a reader sees, and they carry the
+# waiver recorded in issue #48 instead of a scenario. The remaining tests are
+# bridged to features/language-chrome.feature and
+# features/content-fragment-languages.feature and are named after their scenario
+# titles, with Given/When/Then comment anchors inside them.
+#
+# Each test builds an isolated temporary profile tree so the real repository is
+# never touched.
 
 require 'minitest/autorun'
 require 'tmpdir'
@@ -246,7 +250,7 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
-  def test_rejects_missing_interface_term
+  def test_interface_wording_of_a_language_must_be_complete
     with_artifacts(
       [{ id: 'ART-001-example', slug: 'example', language: 'de' }],
       ui_terms: {
@@ -274,7 +278,7 @@ class ProfileLanguageTest < Minitest::Test
 
   # Content in a language without interface terms would render German chrome
   # around a translated page, so the missing file is an error rather than a gap.
-  def test_rejects_content_language_without_interface_terms
+  def test_a_language_that_has_content_must_have_interface_terms
     with_artifacts(
       [
         { id: 'ART-001-example', slug: 'example', language: 'de' },
@@ -290,7 +294,7 @@ class ProfileLanguageTest < Minitest::Test
   # docheader.adoc includes the default terms unconditionally, so a missing
   # directory breaks every page. It must produce the same contract error as a
   # missing file rather than silently skipping the whole check.
-  def test_rejects_missing_interface_terms_directory
+  def test_interface_wording_of_a_language_must_be_completes_directory
     with_artifacts([{ id: 'ART-001-example', slug: 'example', language: 'de' }], ui_terms: {}) do |validator|
       assert_error_matching(validator, %r{missing interface terms for the default language: includes/i18n/ui-de\.adoc})
     end
@@ -326,7 +330,7 @@ class ProfileLanguageTest < Minitest::Test
   # A page reference resolves to the same-language page where one exists and to
   # the default language otherwise, so it always leads somewhere. The fallback is
   # marked with the language it leads to.
-  def test_link_registry_resolves_per_language_and_marks_fallbacks
+  def test_page_reference_resolves_to_the_same_language_page
     with_artifacts(
       [
         { id: 'PAGE-001-index', slug: 'index', dir: 'site', type: 'ProfilePage', language: 'de' },
@@ -354,6 +358,29 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
+  def test_page_reference_falls_back_and_names_the_language_it_leads_to
+    # Given: a page that exists in the default language only
+    with_artifacts(
+      [
+        { id: 'PAGE-001-index', slug: 'index', dir: 'site', type: 'ProfilePage', language: 'de' },
+        { id: 'PAGE-002-legal', slug: 'legal', dir: 'site', type: 'ProfilePage', language: 'de' },
+        { id: 'PAGE-001-index-en', slug: 'index', dir: 'site/en', type: 'ProfilePage', language: 'en',
+          translation_of: 'PAGE-001-index' }
+      ],
+      ui_terms: BILINGUAL_UI_TERMS
+    ) do |validator, root, artifacts|
+      # When: the link registries are generated
+      validator.generate_link_registries(artifacts)
+      english = (root + 'includes/generated/i18n/links-en.adoc').read
+
+      # Then: the other language resolves the reference to the default-language
+      # page and marks it
+      assert_includes english, ":url_legal: {basedir}/legal.html\n"
+      assert_includes english, ":url_legal_lang: de\n"
+      assert_includes english, ":url_legal_marker: {nbsp}(de)\n"
+    end
+  end
+
   # The registry is included into the AsciiDoc document header. ':name:value'
   # without the space is not an attribute entry and would end the header, leaving
   # every later reference unresolved and the site on the default theme.
@@ -375,7 +402,7 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
-  def test_rejects_unknown_page_reference
+  def test_a_reference_no_page_can_satisfy_is_rejected
     Dir.mktmpdir('profile-language-test') do |dir|
       root = Pathname.new(dir)
       (root + 'includes/i18n').mkpath
@@ -418,7 +445,7 @@ class ProfileLanguageTest < Minitest::Test
 
   # A link leading to a German page is usable, so it falls back. A German
   # paragraph inside an English page is not, so the build stops instead.
-  def test_rejects_fragment_missing_in_the_page_language
+  def test_a_fragment_missing_in_the_page_language_stops_the_build
     with_fragments(
       pages: { 'en/index.adoc' => "= Index\ninclude::{includesdir}/i18n/{lang}/profile/bio.adoc[]\n" },
       fragments: { 'de/profile/bio.adoc' => "Deutscher Text\n" }
@@ -427,7 +454,7 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
-  def test_rejects_fragment_of_another_language
+  def test_a_fragment_of_another_language_stops_the_build
     with_fragments(
       pages: { 'en/index.adoc' => "= Index\ninclude::{includesdir}/i18n/de/profile/bio.adoc[]\n" },
       fragments: { 'de/profile/bio.adoc' => "Deutscher Text\n" }
@@ -436,7 +463,7 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
-  def test_accepts_fragment_translated_into_the_page_language
+  def test_a_translated_fragment_is_accepted
     with_fragments(
       pages: { 'en/index.adoc' => "= Index\ninclude::{includesdir}/i18n/{lang}/profile/bio.adoc[]\n" },
       fragments: {
@@ -450,7 +477,7 @@ class ProfileLanguageTest < Minitest::Test
 
   # Fragments reached through an attribute-driven include must be checked too;
   # the CV builds its project and experience entries that way.
-  def test_follows_attribute_driven_and_nested_includes
+  def test_fragments_reached_through_attributes_are_checked_too
     with_fragments(
       pages: { 'en/index.adoc' => "= Index\ninclude::{includesdir}/i18n/{lang}/projects/list.adoc[]\n" },
       fragments: {
@@ -469,7 +496,7 @@ class ProfileLanguageTest < Minitest::Test
   end
 
   # Untranslated fragments nobody includes are a gap, not a failure.
-  def test_reports_untranslated_fragments_as_coverage_warning
+  def test_untranslated_fragments_nobody_includes_are_reported_as_coverage
     with_fragments(
       pages: { 'en/index.adoc' => "= Index\n" },
       fragments: { 'de/profile/bio.adoc' => "Deutscher Text\n" }
@@ -516,7 +543,7 @@ class ProfileLanguageTest < Minitest::Test
 
   # Article chrome resolves its wording through the page it lands on, so a
   # translated article gets translated navigation without a second generator pass.
-  def test_article_chrome_wording_is_resolved_by_the_page
+  def test_article_chrome_takes_its_wording_from_the_page_it_lands_on
     with_artifacts(
       [
         { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
@@ -538,26 +565,39 @@ class ProfileLanguageTest < Minitest::Test
     end
   end
 
-  # A recommendation is swapped for its variant in the reader's language, and one
-  # that exists only in the default language is still offered - marked.
-  def test_related_articles_prefer_the_page_language_and_mark_the_rest
-    with_artifacts(
-      [
-        { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
-        { id: 'ART-001-en', slug: 'first', dir: 'site/en/articles', language: 'en', tags: %w[architecture],
-          translation_of: 'ART-001-de' },
-        { id: 'ART-002-de', slug: 'second', dir: 'site/articles', language: 'de', tags: %w[architecture] },
-        { id: 'ART-003-en', slug: 'third', dir: 'site/en/articles', language: 'en', tags: %w[architecture] }
-      ],
-      ui_terms: BILINGUAL_UI_TERMS
-    ) do |validator, root, artifacts|
-      validator.generate_article_navigation(artifacts)
-      english = (root + 'site/en/articles/generated/third-navigation.adoc').read
+  # Recommendations across languages. Both scenarios share one tree: an article
+  # available in both languages, one available in German only, and the English
+  # article the reader is on.
+  RECOMMENDATION_TREE = [
+    { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+    { id: 'ART-001-en', slug: 'first', dir: 'site/en/articles', language: 'en', tags: %w[architecture],
+      translation_of: 'ART-001-de' },
+    { id: 'ART-002-de', slug: 'second', dir: 'site/articles', language: 'de', tags: %w[architecture] },
+    { id: 'ART-003-en', slug: 'third', dir: 'site/en/articles', language: 'en', tags: %w[architecture] }
+  ].freeze
 
-      # The English variant of ART-001 wins over its German original, unmarked.
-      assert_includes english, 'first.html'
-      # ART-002 exists in German only and is offered with its language marked.
-      assert_match(/second\.html">[^<]*&#160;\(de\)</, english)
+  def test_a_recommendation_is_resolved_to_the_language_of_the_reader
+    # Given: an article recommended in two languages and a reader on an English article
+    with_artifacts(RECOMMENDATION_TREE, ui_terms: BILINGUAL_UI_TERMS) do |validator, root, artifacts|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: the English variant is recommended without a language marker
+      english = (root + 'site/en/articles/generated/third-navigation.adoc').read
+      assert_match(%r{first\.html">[^<]*</a>}, english)
+      refute_match(%r{first\.html">[^<]*&\#160;\(de\)}, english)
+    end
+  end
+
+  def test_a_recommendation_available_in_one_language_only_names_that_language
+    # Given: an article that exists in the default language only
+    with_artifacts(RECOMMENDATION_TREE, ui_terms: BILINGUAL_UI_TERMS) do |validator, root, artifacts|
+      # When: the article navigation is generated
+      validator.generate_article_navigation(artifacts)
+
+      # Then: it is still recommended and marked with the language it leads to
+      english = (root + 'site/en/articles/generated/third-navigation.adoc').read
+      assert_match(/second\.html">[^<]*&\#160;\(de\)</, english)
     end
   end
 
@@ -582,7 +622,7 @@ class ProfileLanguageTest < Minitest::Test
 
   # Each language variant is its own artifact, so its comment thread and its
   # allowlist entry follow from its own ID without any extra rule.
-  def test_comment_threads_are_separate_per_language_variant
+  def test_each_language_variant_has_its_own_comment_thread
     with_artifacts(
       [
         { id: 'ART-001-de', slug: 'first', dir: 'site/articles', language: 'de', channels: %w[website] },

--- a/test/site_metadata_injector_test.rb
+++ b/test/site_metadata_injector_test.rb
@@ -58,7 +58,7 @@ class SiteMetadataInjectorTest < Minitest::Test
   # The default language stays at the site root while every other language lives
   # in its own subtree, so a language variant must keep its prefix in the
   # canonical URL instead of collapsing onto the German page.
-  def test_language_subtree_pages_keep_their_language_prefix
+  def test_language_subtree_pages_keep_their_language_prefix_in_the_canonical_url
     with_site(%w[index.html en/index.html en/articles/example.html]) do |site|
       injector = SiteMetadataInjector.new(site_dir: site, base_url: 'https://example.test')
 


### PR DESCRIPTION
Closes #65. Closes the process gap in #47.

Brings the multilingual slices back under the repository's BDD default. The behaviour was covered by tests all along — what was missing was the Living Documentation layer and the scenario-to-test bridge.

**No production code is touched.** `git diff --stat` over `scripts/`, `src-content/`, `build.gradle` and `metamodel/` is empty; the rendered site is unchanged.

## Two feature files for behaviour that had no home

**`features/language-chrome.feature`** — the class with the deliberately opposite rules from ADR-010: a page reference falls back to the default language and says so, while interface wording has nowhere to say it and must therefore be complete or the build fails. Six scenarios.

**`features/content-fragment-languages.feature`** — the third class, which does not fall back at all, including the attribute-driven include chain and the coverage warning. Five scenarios.

## Extended where scenarios were missing

| File | Added |
|---|---|
| `article-navigation.feature` | recommendation resolved to the reader's language; one available in a single language names it; an article is not recommended as related to its own translation |
| `article-comments.feature` | wording follows the page language; each variant has its own thread |
| `canonical-site-urls.feature` | language subtree keeps its prefix |

`article-listings.feature` already got its language scenarios in #57.

## Traceability is now mechanically checkable

Test names and sanitized scenario titles match **exactly**, so the convention no longer needs an eye to verify:

```
scenarios: 73   unbridged: 0
```

Getting there surfaced three things:

* **One test covered two scenarios** (`related articles prefer the page language and mark the rest`). Split, so each scenario has its own identifiable verification.
* **Three titles were less precise than their tests.** The scenario said *"Only published article ids are synchronized"* while the test knew it is the *website channel* that decides. The title moved to the test's wording, not the other way round.
* **One title carried a possessive** that no sanitizing scheme renders cleanly. Reworded to *"resolved to the language of the reader"*.

I did not add a check script: `skills/bdd-specification` says not to implement a runner as part of applying it, and the issue kept automation out of scope. The check above was run once, by hand, and is reproducible from the convention.

## Also corrected

`test/profile_language_test.rb` claimed in its header that no feature is bridged there. That was true when the file only held metadata validation; it has carried reader-visible behaviour since #51. The header now distinguishes the two kinds of test and names the waiver from #48 for the author-facing half.

## Verification

| Suite | Result |
|---|---|
| `profile_language` | 36 runs, 108 assertions, 0 failures |
| `profile_cv_language` | 4 runs, 25 assertions, 0 failures |
| `profile_language_alternates` | 4 runs, 21 assertions, 0 failures |
| `profile_translation` | 7 runs, 27 assertions, 0 failures |
| `profile_navigation` | 15 runs, 55 assertions, 0 failures |
| `profile_listings` | 16 runs, 80 assertions, 0 failures |
| `profile_comments` | 7 runs, 60 assertions, 0 failures |
| `site_metadata_injector` | 11 runs, 28 assertions, 0 failures |
| `article_comments` (node) | 3 pass, 0 fail |
| Profile validator | 0 errors |
| Architecture validator | 55 artifacts, 0 errors, 0 warnings |
