### PR TITLE
Add session skills and run the first clock-out

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,14 @@ Locate the toolkit in this order:
 - Profile metadata follows `metamodel/profile-artifact.schema.yaml`.
 - Use `ai-contracts/profile-artifact-metadata.md` for repeatable AI-assisted profile metadata work.
 - Use `skills/profile-artifact-maintenance/SKILL.md` when changing profile pages, CV content, articles, shorts, project entries, or profile metadata.
+
+## Working Sessions
+
+- Start a session with `skills/clock-in/SKILL.md`: establish the repository state from the tools, then pick up a topic from `progress/`.
+- End a session with `skills/clock-out/SKILL.md`: refresh the progress files for the topics touched and write the day's diary entry.
+- Write diary entries with `skills/diary/SKILL.md`. The diary records why a wrong belief was plausible; it is not architecture documentation.
+- `progress/<topic>.adoc` says where a topic is and is rewritten wholesale. `diary/YYYY-MM-DD-<slug>.adoc` says what was learned and is append-only once the day is closed.
+- These three skills are local for now. They are expected to move into the architecture-knowledge-toolkit; until then do not reference a toolkit equivalent.
 - Run `./gradlew validateProfileMetamodel` or `./gradlew generateProfileArtifacts` after changing profile metadata.
 
 ## AI Contracts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ Locate the toolkit in this order:
 - End a session with `skills/clock-out/SKILL.md`: refresh the progress files for the topics touched and write the day's diary entry.
 - Write diary entries with `skills/diary/SKILL.md`. The diary records why a wrong belief was plausible; it is not architecture documentation.
 - `progress/<topic>.adoc` says where a topic is and is rewritten wholesale. `diary/YYYY-MM-DD-<slug>.adoc` says what was learned and is append-only once the day is closed.
-- These three skills are local for now. They are expected to move into the architecture-knowledge-toolkit; until then do not reference a toolkit equivalent.
+- Choose the register before writing with `skills/language-profile/SKILL.md`. It decides how an artifact reads; the toolkit decides what it contains.
+- These four skills are local for now. They are expected to move into the architecture-knowledge-toolkit; until then do not reference a toolkit equivalent.
 - Run `./gradlew validateProfileMetamodel` or `./gradlew generateProfileArtifacts` after changing profile metadata.
 
 ## AI Contracts

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -19,6 +19,9 @@ When Codex performs AI-assisted work in this repository:
 Paths are relative to the profile-dieterbaier repository root.
 
 - `article-summary-pack`: `skills/article-summary-pack/SKILL.md`
+- `clock-in`: `skills/clock-in/SKILL.md`
+- `clock-out`: `skills/clock-out/SKILL.md`
+- `diary`: `skills/diary/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/codex/AGENTS.md
+++ b/adapters/codex/AGENTS.md
@@ -22,6 +22,7 @@ Paths are relative to the profile-dieterbaier repository root.
 - `clock-in`: `skills/clock-in/SKILL.md`
 - `clock-out`: `skills/clock-out/SKILL.md`
 - `diary`: `skills/diary/SKILL.md`
+- `language-profile`: `skills/language-profile/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/cursor/rules/profile-dieterbaier.mdc
+++ b/adapters/cursor/rules/profile-dieterbaier.mdc
@@ -26,6 +26,7 @@ Paths are relative to the profile-dieterbaier repository root.
 - `clock-in`: `skills/clock-in/SKILL.md`
 - `clock-out`: `skills/clock-out/SKILL.md`
 - `diary`: `skills/diary/SKILL.md`
+- `language-profile`: `skills/language-profile/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/cursor/rules/profile-dieterbaier.mdc
+++ b/adapters/cursor/rules/profile-dieterbaier.mdc
@@ -23,6 +23,9 @@ When Cursor performs AI-assisted work in this repository:
 Paths are relative to the profile-dieterbaier repository root.
 
 - `article-summary-pack`: `skills/article-summary-pack/SKILL.md`
+- `clock-in`: `skills/clock-in/SKILL.md`
+- `clock-out`: `skills/clock-out/SKILL.md`
+- `diary`: `skills/diary/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/github-copilot/copilot-instructions.md
+++ b/adapters/github-copilot/copilot-instructions.md
@@ -19,6 +19,9 @@ When GitHub Copilot performs AI-assisted work in this repository:
 Paths are relative to the profile-dieterbaier repository root.
 
 - `article-summary-pack`: `skills/article-summary-pack/SKILL.md`
+- `clock-in`: `skills/clock-in/SKILL.md`
+- `clock-out`: `skills/clock-out/SKILL.md`
+- `diary`: `skills/diary/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/github-copilot/copilot-instructions.md
+++ b/adapters/github-copilot/copilot-instructions.md
@@ -22,6 +22,7 @@ Paths are relative to the profile-dieterbaier repository root.
 - `clock-in`: `skills/clock-in/SKILL.md`
 - `clock-out`: `skills/clock-out/SKILL.md`
 - `diary`: `skills/diary/SKILL.md`
+- `language-profile`: `skills/language-profile/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/vibe/AGENTS.md
+++ b/adapters/vibe/AGENTS.md
@@ -19,6 +19,9 @@ When Vibe performs AI-assisted work in this repository:
 Paths are relative to the profile-dieterbaier repository root.
 
 - `article-summary-pack`: `skills/article-summary-pack/SKILL.md`
+- `clock-in`: `skills/clock-in/SKILL.md`
+- `clock-out`: `skills/clock-out/SKILL.md`
+- `diary`: `skills/diary/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/adapters/vibe/AGENTS.md
+++ b/adapters/vibe/AGENTS.md
@@ -22,6 +22,7 @@ Paths are relative to the profile-dieterbaier repository root.
 - `clock-in`: `skills/clock-in/SKILL.md`
 - `clock-out`: `skills/clock-out/SKILL.md`
 - `diary`: `skills/diary/SKILL.md`
+- `language-profile`: `skills/language-profile/SKILL.md`
 - `profile-artifact-maintenance`: `skills/profile-artifact-maintenance/SKILL.md`
 - `write-article`: `skills/write-article/SKILL.md`
 

--- a/diary/2026-08-02-what-only-real-content-revealed.adoc
+++ b/diary/2026-08-02-what-only-real-content-revealed.adoc
@@ -1,0 +1,118 @@
+== Day 2 — 2 August 2026: What only real content revealed
+
+Elf Slices des Epics #47 wurden heute integriert (#62 bis #73), dazu die
+Pilotübersetzung und ein Fehler, der erst auf der Live-Seite auffiel. Die
+lehrreichen Stellen waren nicht die Mechanik, sondern das, was die Mechanik erst
+zeigte, als echte Inhalte durch sie liefen.
+
+=== Vier Fehler, die eine zweite Sprache brauchten, um sichtbar zu werden
+
+Bis zum Pilot in #57 gab es genau einen deutschen Artikelbaum. Alles war grün.
+Mit dem zweiten Artikel in einer zweiten Sprache fielen an einem Nachmittag vier
+Dinge auf, die vorher strukturell unentscheidbar waren:
+
+`articles_base_dir` bestimmte das Artikelverzeichnis aus dem gemeinsamen
+Vorfahren aller Artikelquellen. Bei drei deutschen Artikeln in zwei
+Unterverzeichnissen ergibt das zufällig das Richtige. Bei *einem* englischen
+Artikel ergibt es dessen eigenes Unterverzeichnis, und `/en/articles/lists/`
+entstand nie.
+
+Die generierten Listenseiten setzten `:basedir: ../..` hart. Das stimmt nur für
+die Default-Sprache direkt unter der Site-Wurzel. Die englischen Listen luden
+ihr Stylesheet aus `/en/stylesheet/style.css` und waren komplett ungestylt.
+
+Der deutsche Artikel empfahl sich selbst: seine englische Übersetzung teilt seine
+Tags, geriet damit in die Related-Liste, und der Sprach-Swap aus #53 löste diese
+Empfehlung zurück auf das deutsche Original auf.
+
+Der Sprachumschalter stapelte auf Mobilgeräten, weil der Breakpoint
+`flex-direction: column` auf *jede* Navigationsliste setzte. Solange die obere
+Zeile nur „Home" enthielt, war das unsichtbar.
+
+Keiner dieser vier Fehler war ein Denkfehler im Entwurf. Alle vier waren
+Annahmen, die bei einer Sprache und drei Artikeln nicht falsifizierbar waren.
+
+=== Zweimal dieselbe Falle im AsciiDoc-Header
+
+Interface-Begriffe und die Link-Registry werden in den Dokument-Header
+inkludiert. Dort beendet eine Leerzeile den Header — und, wie sich zeigte, auch
+eine Kommentarzeile innerhalb eines Includes. Alles danach hört auf, Header-
+Attribut zu sein. In #49 hieß das: `:stylesheet:` und `:copycss:` wirkungslos,
+die gesamte Seite fiel auf das Asciidoctor-Default-CSS zurück.
+
+Das Symptom sieht nach kaputtem Theme aus, nicht nach kaputtem Include.
+
+In #51 passierte es ein zweites Mal, in anderer Gestalt: `:name:value` ohne
+Leerzeichen nach dem Doppelpunkt ist keine Attributzeile. Der erste
+Fallback-Marker erzeugte genau das, und alle späteren Referenzen blieben als
+`{url_cv}` im Text stehen.
+
+Nach dem zweiten Mal prüft ein Test jede generierte Registry-Zeile gegen das
+Attributformat, und die Regel steht in `src-content/profile/includes/i18n/README.md`
+statt in einem Kommentar *in* den Dateien — dort wäre sie selbst der Auslöser.
+
+=== Eine Entscheidung, die eine Mechanik überflüssig machte
+
+Der ADR sah zunächst vor, dass Fragmente auf Deutsch zurückfallen und der
+Fallback sichtbar markiert wird. Beim Review verwarf der Owner das: ein
+deutscher Absatz mitten in einem englischen Artikel sei für den Leser
+unbrauchbar, der Build solle abbrechen.
+
+Das kollidierte mit der früheren Festlegung und war die stärkere Regel. Die
+Auflösung ergab eine Leitlinie, die den Rest des Epics getragen hat:
+**Verweise fallen zurück, Inhalte nicht.** Ein deutscher Link ist benutzbar und
+sagt `(de)`; ein deutscher Absatz ist es nicht.
+
+Der Nebeneffekt war die eigentliche Überraschung: die geplante
+Stub-Generierung — Spiegeln des `de`-Baums, Marker-Kommentare, eigene
+Clean-Logik — entfiel damit ersatzlos. Ein Fragment existiert in der
+Seitensprache, oder der Build stoppt. Validierung statt Generierung.
+
+=== Eine Aussage, die nicht generierbar war
+
+Für die Artikellisten war ein Hinweis geplant: „Auf Englisch ist 1 weiterer
+Artikel verfügbar." Der Owner hielt dagegen, dass „weiterer" falsch wird, sobald
+die andere Sprache *weniger* Artikel hat — und dass die Aussage pro Sprache, pro
+Tag und pro Skill korrekt sein müsste.
+
+Die Konsequenz war keine zusätzliche Logik, sondern eine Formulierung ohne
+Mengenaussage: welche Sprachen publizieren, nicht wie viel. Das bleibt bei jeder
+Artikelzahl wahr und skaliert auf beliebig viele Sprachen. Die fragile Stelle
+wurde nicht abgesichert, sondern entfernt.
+
+=== Der Fehler, der bis auf die Live-Seite durchkam
+
+`https://dieterbaier.eu/en/articles/lists/all.html` lieferte 404, während der
+Rest von `/en/` erreichbar war. Das Build-Log der deployenden Ausführung zeigte
+`> Task :buildArticleListPagesEn NO-SOURCE`, obwohl der Generator 50 Sekunden
+vorher im selben Lauf `Generated 11 article list file(s)` gemeldet hatte.
+
+Lokal war es nicht reproduzierbar: sauberer Baum, dieselbe Task-Kombination wie
+CI, ohne Daemon nach `--stop` — jedes Mal grün. Im Container schon; dort liefen
+die beiden Tasks sogar in umgekehrter Reihenfolge.
+
+Die Konstruktion hing daran, dass eine Asciidoctor-Task auf ein Verzeichnis
+zeigt, das erst während des Builds entsteht. Statt die Instanz weiter zu jagen,
+wurde die Fehlerklasse entfernt: Listenseiten werden jetzt dort erzeugt, wo sie
+veröffentlicht werden, und der normale Site-Build rendert sie als gewöhnliche
+Quellen. 67 Zeilen Build-Logik fielen weg, dazu eine doppelte
+Canonical-Injektion und ein Streuverzeichnis im Output.
+
+Der Fix hätte es beinahe nicht auf die Seite geschafft: sein Deploy-Lauf wurde
+vom nächsten Merge per `cancel-in-progress` abgebrochen, und der Folgelauf
+übersprang `build-docs`, weil dieser Commit nur `features/` und `test/`
+berührte. Das ist #74.
+
+=== Was der BDD-Default gekostet hat, weil er ausgesetzt wurde
+
+Ab #49 entstanden Szenarien nicht mehr mit, obwohl der Toolkit-Skill sie als
+strikten Default für beobachtbares Verhalten vorschreibt. Am deutlichsten bei
+#53: dessen Verifikationsabschnitt forderte wörtlich die Erweiterung von drei
+Feature-Dateien — geschrieben beim Slicing, umgesetzt beim Implementieren nicht.
+
+Aufgefallen ist es nicht beim Arbeiten, sondern durch die Frage des Owners, ob
+das Absicht sei. Der Nachzug in #65 kostete einen eigenen Slice und brachte drei
+Dinge ans Licht, die beim Mitschreiben nicht entstanden wären: ein Test, der
+zwei Szenarien gleichzeitig abdeckte, drei Szenariotitel, die unpräziser waren
+als ihre Tests, und ein Kopfkommentar, der behauptete, in dieser Datei sei kein
+Feature gebrückt — was seit #51 nicht mehr stimmte.

--- a/diary/2026-08-02-what-only-real-content-revealed.adoc
+++ b/diary/2026-08-02-what-only-real-content-revealed.adoc
@@ -138,3 +138,22 @@ Register danach wählen, was der Lebenszyklus mit einem Text tut, wenn er sich
 als falsch erweist. Die Profiltabelle selbst mussten wir neu füllen. Das ist
 zugleich die erste Evidenz, dass der Mechanismus reist und die Profile nicht;
 im Skill steht es als Bedingung dafür, wann er stromaufwärts gehört.
+
+=== Ein Toolkit-Fehler, den wir nicht geprüft hatten
+
+Beim Clock-out hielt ich fest, das Toolkit widerspreche sich: sein `adr`-Skill
+verlange `derived_from`, sein Schema verbiete es. Der Owner vermutete, der
+Befund existiere bereits als Issue — und diese Vermutung war der Anlass, ihn
+überhaupt zu prüfen.
+
+Das Toolkit-Schema kennt `derived_from` seit Zeile 83. Verboten hat es *unsere
+Kopie*. Ich hatte aus einer lokalen Datei auf einen fremden Defekt geschlossen,
+ohne die fremde Datei zu öffnen — und war im Begriff, ein Issue gegen ein
+Projekt anzulegen, das den Fehler nicht hat.
+
+Plausibel war es, weil beide Dateien denselben Namen tragen und aus derselben
+Quelle stammen. Genau das ist die Eigenschaft von kopierten Assets, die
+docs-as-code-toolkit#26 beschreibt: sie sehen weiter wie das Original aus,
+nachdem sie es nicht mehr sind. Der Fehler war nicht die Vermutung, sondern
+dass ich sie ohne den einen `grep` aufgeschrieben habe, der sie widerlegt.
+

--- a/diary/2026-08-02-what-only-real-content-revealed.adoc
+++ b/diary/2026-08-02-what-only-real-content-revealed.adoc
@@ -53,10 +53,11 @@ statt in einem Kommentar *in* den Dateien — dort wäre sie selbst der Auslöse
 
 === Eine Entscheidung, die eine Mechanik überflüssig machte
 
-Der ADR sah zunächst vor, dass Fragmente auf Deutsch zurückfallen und der
-Fallback sichtbar markiert wird. Beim Review verwarf der Owner das: ein
-deutscher Absatz mitten in einem englischen Artikel sei für den Leser
-unbrauchbar, der Build solle abbrechen.
+Ich hatte im ADR vorgesehen, dass Fragmente auf Deutsch zurückfallen und der
+Fallback sichtbar markiert wird — analog zu den Verweisen, wo genau das
+funktioniert. Beim Review verwarf der Owner es: ein deutscher Absatz mitten in
+einem englischen Artikel sei für den Leser unbrauchbar, der Build solle
+abbrechen.
 
 Das kollidierte mit der früheren Festlegung und war die stärkere Regel. Die
 Auflösung ergab eine Leitlinie, die den Rest des Epics getragen hat:
@@ -70,10 +71,10 @@ Seitensprache, oder der Build stoppt. Validierung statt Generierung.
 
 === Eine Aussage, die nicht generierbar war
 
-Für die Artikellisten war ein Hinweis geplant: „Auf Englisch ist 1 weiterer
-Artikel verfügbar." Der Owner hielt dagegen, dass „weiterer" falsch wird, sobald
-die andere Sprache *weniger* Artikel hat — und dass die Aussage pro Sprache, pro
-Tag und pro Skill korrekt sein müsste.
+Ich hatte für die Artikellisten einen Hinweis vorgeschlagen: „Auf Englisch ist
+1 weiterer Artikel verfügbar." Der Owner hielt dagegen, dass „weiterer" falsch
+wird, sobald die andere Sprache *weniger* Artikel hat — und dass die Aussage pro
+Sprache, pro Tag und pro Skill korrekt sein müsste.
 
 Die Konsequenz war keine zusätzliche Logik, sondern eine Formulierung ohne
 Mengenaussage: welche Sprachen publizieren, nicht wie viel. Das bleibt bei jeder
@@ -87,13 +88,13 @@ Rest von `/en/` erreichbar war. Das Build-Log der deployenden Ausführung zeigte
 `> Task :buildArticleListPagesEn NO-SOURCE`, obwohl der Generator 50 Sekunden
 vorher im selben Lauf `Generated 11 article list file(s)` gemeldet hatte.
 
-Lokal war es nicht reproduzierbar: sauberer Baum, dieselbe Task-Kombination wie
-CI, ohne Daemon nach `--stop` — jedes Mal grün. Im Container schon; dort liefen
-die beiden Tasks sogar in umgekehrter Reihenfolge.
+Wir konnten es lokal nicht reproduzieren: sauberer Baum, dieselbe
+Task-Kombination wie CI, ohne Daemon nach `--stop` — jedes Mal grün. Im
+Container schon; dort liefen die beiden Tasks sogar in umgekehrter Reihenfolge.
 
 Die Konstruktion hing daran, dass eine Asciidoctor-Task auf ein Verzeichnis
 zeigt, das erst während des Builds entsteht. Statt die Instanz weiter zu jagen,
-wurde die Fehlerklasse entfernt: Listenseiten werden jetzt dort erzeugt, wo sie
+entfernten wir die Fehlerklasse: Listenseiten werden jetzt dort erzeugt, wo sie
 veröffentlicht werden, und der normale Site-Build rendert sie als gewöhnliche
 Quellen. 67 Zeilen Build-Logik fielen weg, dazu eine doppelte
 Canonical-Injektion und ein Streuverzeichnis im Output.
@@ -105,14 +106,35 @@ berührte. Das ist #74.
 
 === Was der BDD-Default gekostet hat, weil er ausgesetzt wurde
 
-Ab #49 entstanden Szenarien nicht mehr mit, obwohl der Toolkit-Skill sie als
-strikten Default für beobachtbares Verhalten vorschreibt. Am deutlichsten bei
+Ab #49 schrieb ich die Szenarien nicht mehr mit, obwohl der Toolkit-Skill sie
+als strikten Default für beobachtbares Verhalten vorschreibt. Am deutlichsten bei
 #53: dessen Verifikationsabschnitt forderte wörtlich die Erweiterung von drei
 Feature-Dateien — geschrieben beim Slicing, umgesetzt beim Implementieren nicht.
 
-Aufgefallen ist es nicht beim Arbeiten, sondern durch die Frage des Owners, ob
-das Absicht sei. Der Nachzug in #65 kostete einen eigenen Slice und brachte drei
-Dinge ans Licht, die beim Mitschreiben nicht entstanden wären: ein Test, der
+Aufgefallen ist es mir nicht beim Arbeiten, sondern durch die Frage des Owners,
+ob das Absicht sei. Der Nachzug in #65 kostete einen eigenen Slice und brachte
+drei Dinge ans Licht, die beim Mitschreiben nicht entstanden wären: ein Test, der
 zwei Szenarien gleichzeitig abdeckte, drei Szenariotitel, die unpräziser waren
 als ihre Tests, und ein Kopfkommentar, der behauptete, in dieser Datei sei kein
 Feature gebrückt — was seit #51 nicht mehr stimmte.
+
+=== Drei Skills aus einem anderen Projekt geholt
+
+Zum Tagesabschluss übernahmen wir `clock-in`, `clock-out` und `diary` aus dem
+Budget-Projekt, damit eine Sitzung übergeben werden kann, ohne sich auf
+Erinnerung zu stützen. Sie sollen später ins architecture-knowledge-toolkit
+wandern; bis dahin liegen sie lokal.
+
+Beim Portieren zeigte sich, dass `diary` an einem vierten Skill hängt:
+`language-profile`, Profil 5, entscheidet, wie ein Eintrag *klingt*. Ein
+Verweis darauf ins Leere hätte die Lücke unsichtbar gemacht, also stand sie
+zuerst benannt im Skill — und wurde im selben Zug geschlossen, als der Owner
+den vierten Skill nachzog.
+
+Die Portierung war keine Kopie. Das Budget-Projekt schreibt sein
+`language-profile` gegen ADR-022 und ADR-023, die es hier nicht gibt, und
+gegen Beispiele aus seiner eigenen Domäne. Übertragbar war der *Mechanismus* —
+Register danach wählen, was der Lebenszyklus mit einem Text tut, wenn er sich
+als falsch erweist. Die Profiltabelle selbst mussten wir neu füllen. Das ist
+zugleich die erste Evidenz, dass der Mechanismus reist und die Profile nicht;
+im Skill steht es als Bedingung dafür, wann er stromaufwärts gehört.

--- a/diary/diary.adoc
+++ b/diary/diary.adoc
@@ -1,0 +1,35 @@
+= Development Diary
+Dieter Baier
+:toc: left
+:toclevels: 2
+:icons: font
+:sectanchors:
+:sectlinks:
+
+A working record of this project: what was decided, what was rejected, and —
+mostly — what turned out to be wrong.
+
+This is not architecture documentation. The decisions live in
+`src-content/docs/arc42/09-architecture-decisions/`, the constraints in
+`src-content/docs/arc42/doc-02000-architecture-constraints.adoc`, and those are
+the authority. This diary is the story around them: the reasoning that did not
+fit in an ADR, and the mistakes an ADR has no place to record.
+
+Each recap is its own document, included here. They are written from the commit
+history, the issues and the pull requests, so the dates and numbers are
+checkable rather than remembered.
+
+Two recaps are cross-cutting rather than chronological, and are the ones worth
+reading first: the through-line, which is the single lesson these days keep
+teaching, and the toolkit validation, which is what using the
+architecture-knowledge-toolkit confirmed or contradicted.
+
+include::through-line.adoc[]
+
+include::2026-08-02-what-only-real-content-revealed.adoc[]
+
+include::toolkit-validation.adoc[]
+
+include::working-agreements.adoc[]
+
+include::open-threads.adoc[]

--- a/diary/open-threads.adoc
+++ b/diary/open-threads.adoc
@@ -50,3 +50,16 @@ vorliegen, bevor die Seite baut. Das ist Autorenarbeit über eine reale Laufbahn
 Die Alternative wäre, den CV feiner zu schneiden, damit kleinere Einheiten
 blockieren — Fragmentgranularität ist seit #52 ein Entwurfshebel und im ADR
 festgehalten.
+
+=== Ein Toolkit-Issue, das noch anzulegen ist
+
+`derived_from` steht im ADR-Template des Toolkits, aber
+`metamodel/artifact.schema.yaml` hat `additionalProperties: false` und kennt das
+Feld nicht. Die Issue-Suche im Toolkit brachte keinen Treffer, der das
+beschreibt.
+
+Offen ist nicht *ob*, sondern in welche Richtung: Schema erweitern, oder im
+Skill festhalten, dass ein Projekt `derived_from` weglassen darf. Die Begründung
+steht in `toolkit-validation.adoc`; hier steht sie, weil sie dieses Projekt
+überlebt.
+

--- a/diary/open-threads.adoc
+++ b/diary/open-threads.adoc
@@ -51,15 +51,22 @@ Die Alternative wäre, den CV feiner zu schneiden, damit kleinere Einheiten
 blockieren — Fragmentgranularität ist seit #52 ein Entwurfshebel und im ADR
 festgehalten.
 
-=== Ein Toolkit-Issue, das noch anzulegen ist
+=== Das divergierte Metamodell-Schema
 
-`derived_from` steht im ADR-Template des Toolkits, aber
-`metamodel/artifact.schema.yaml` hat `additionalProperties: false` und kennt das
-Feld nicht. Die Issue-Suche im Toolkit brachte keinen Treffer, der das
-beschreibt.
+`metamodel/artifact.schema.yaml` weicht in beide Richtungen vom Toolkit ab: es
+ergänzt `QualityGoal` und `priority`, und ihm fehlt `derived_from`. Ein Abgleich
+muss deshalb zusammenführen statt überschreiben.
 
-Offen ist nicht *ob*, sondern in welche Richtung: Schema erweitern, oder im
-Skill festhalten, dass ein Projekt `derived_from` weglassen darf. Die Begründung
-steht in `toolkit-validation.adoc`; hier steht sie, weil sie dieses Projekt
-überlebt.
+Offen ist, wie oft das wiederholt wird und woran man die nächste Divergenz
+merkt. Stromaufwärts hängt es an docs-as-code-toolkit#26; lokal ist es #75.
 
+=== Wessen Sprache in src-content/profile gilt
+
+Alles unter `src-content/profile` ist Produktarbeit und trägt die Sprache des
+Autors, nicht ein vom Werkzeug zugewiesenes Register. `language-profile` nimmt
+es deshalb ausdrücklich aus.
+
+Wo die Regel stattdessen hingehört — `write-article`, `article-summary-pack`
+oder beides — ist bewusst offen. Der Auslöser, es zu entscheiden, wäre der erste
+Fall, in dem jemand für veröffentlichte Inhalte eine Vorgabe sucht und sie in
+`language-profile` nicht findet.

--- a/diary/open-threads.adoc
+++ b/diary/open-threads.adoc
@@ -1,0 +1,52 @@
+== Open threads
+
+Bewusst unfertig gelassen, mit der Überlegung dabei, damit die nächste
+Entscheidung nicht bei null anfängt. Was mit seinem Thema stirbt, steht in
+dessen Progress-Datei, nicht hier.
+
+=== Ob Listen künftig alle Sprachen zeigen
+
+Der Owner brachte es zweimal auf: eine Liste, die wirklich *alle* Artikel zeigt,
+mit `(de)`/`(en)`-Markern an den Einträgen. Damit wäre „Alle Artikel" wieder
+wörtlich wahr, und das Marker-Muster existiert auf der Seite bereits.
+
+Dagegen steht die Entscheidung aus #53, dass eine englische Liste keine deutschen
+Artikel aushändigt — und dass der Nachteil genau dann wächst, wenn das Setup
+erfolgreich ist: bei durchgängiger Übersetzung verdoppelt sich jede Liste.
+
+Der Auslöser, es neu zu bewerten, wäre eine Beobachtung, dass Leser tatsächlich
+sprachübergreifend suchen. Vorher ist es eine Wette. Aktuell gelöst durch einen
+Hinweis, der nennt, welche Sprachen publizieren.
+
+=== Flaggen oder Wörter im Sprachumschalter
+
+Entschieden für Flaggen (🇦🇹/🇬🇧), mit dem Sprachnamen auf `title` und
+`aria-label`. Eine Flagge bezeichnet streng genommen ein Land, keine Sprache —
+🇦🇹 für Deutsch ist eine Aussage über den Autor, nicht über die Sprache.
+
+Der Wechsel auf Wörter ist eine reine Term-Änderung, weil alles über
+`{ui_language_*}` läuft. Offen bleibt, ob sich die Flaggen im Betrieb als zu
+implizit erweisen; das zeigt sich erst mit Lesern, die nicht wissen, dass es die
+Seite zweisprachig gibt.
+
+=== Wo sprachabhängige Diagrammquellen liegen sollen
+
+#70 hält zwei Varianten offen: unter `i18n/<lang>/` wie alle Fragmente, oder mit
+Sprachsuffix neben dem Artikel wie das heutige `doc-influences-en.puml`. Die
+erste ist konsistent zur Fragmentregel, die zweite hält Assets bei dem Artikel,
+der sie benutzt.
+
+Ungelöst und wichtiger: wie ein Diagramm als *sprachneutral* markiert wird.
+`doc-pipeline.puml` ist bereits englisch beschriftet und funktioniert in beiden
+Sprachen; ohne Markierung bräuchte jedes rein technische Diagramm Kopien pro
+Sprache.
+
+=== Ob der CV überhaupt übersetzt werden soll
+
+Die Mechanik steht, aber die Fragmentregel macht eine CV-Sprachvariante zu einem
+Alles-oder-nichts: rund 90 Fragmente, darunter 66 Projekteinträge, müssen
+vorliegen, bevor die Seite baut. Das ist Autorenarbeit über eine reale Laufbahn.
+
+Die Alternative wäre, den CV feiner zu schneiden, damit kleinere Einheiten
+blockieren — Fragmentgranularität ist seit #52 ein Entwurfshebel und im ADR
+festgehalten.

--- a/diary/through-line.adoc
+++ b/diary/through-line.adoc
@@ -1,0 +1,37 @@
+== The through-line
+
+Die eine Lehre, die sich in diesem Projekt wiederholt: **eine Annahme, die nur
+ein Beispiel kennt, ist nicht falsifizierbar — und wirkt deshalb wie eine
+Invariante.**
+
+Jede Instanz trägt das Artefakt, was es behauptete, und was es gefangen hätte.
+
+=== Instanzen
+
+`articles_base_dir` (2026-08-02):: Behauptete, das Artikelverzeichnis sei der
+gemeinsame Vorfahre aller Artikelquellen. Bei drei Artikeln in zwei
+Unterverzeichnissen stimmt das zufällig. Bei einem Artikel ist es dessen eigenes
+Unterverzeichnis. Gefangen hätte es: ein zweiter Artikelbaum mit genau einem
+Artikel — also der Pilot, der es dann auch fand.
+
+`:basedir: ../..` in generierten Listenseiten (2026-08-02):: Behauptete eine
+feste Tiefe zur Site-Wurzel. Stimmt für die Default-Sprache, die direkt unter der
+Wurzel liegt. Gefangen hätte es: irgendeine Seite eine Ebene tiefer — es gab bis
+zum Sprach-Subtree keine.
+
+Related-Article-Auswahl (2026-08-02):: Behauptete, ein Artikel könne nicht unter
+seinen eigenen Empfehlungen auftauchen, weil seine ID ausgeschlossen war. Mit
+Übersetzungen teilt eine *andere* ID denselben Inhalt. Gefangen hätte es: zwei
+Artefakte, die denselben Text repräsentieren — vor der Übersetzung gab es das
+Konzept nicht.
+
+`.mainnav ul { flex-direction: column }` (2026-08-02):: Behauptete nichts
+Falsches, war aber unbeobachtbar: die obere Navigationszeile enthielt genau ein
+Element. Gefangen hätte es: ein zweites Element in derselben Zeile.
+
+=== Warum die Sammlung nicht wächst wie erwartet
+
+Alle vier stammen vom selben Tag und vom selben Auslöser: dem Moment, in dem
+Testdaten durch echte Inhalte ersetzt wurden. Das ist die Beobachtung, nicht die
+Zahl. Eine fünfte Instanz, die nur einer der vier ähnelt, gehört nicht hierher —
+Ähnlichkeit ist der Punkt des Dokuments und verdünnt sich mit Menge.

--- a/diary/toolkit-validation.adoc
+++ b/diary/toolkit-validation.adoc
@@ -42,22 +42,27 @@ Wäre der Widerspruch erst beim Implementieren aufgefallen, hätte die
 Stub-Generierung bereits existiert. So entfiel sie ersatzlos, bevor sie gebaut
 wurde.
 
-=== Offen: die Metamodell-Schemata kennen keine Provenienz
+=== Bestätigt: kopierte Toolkit-Assets driften still — zweite Instanz
 
-`metamodel/artifact.schema.yaml` hat `additionalProperties: false` und kein
-`derived_from`, obwohl der `adr`-Skill genau dieses Feld für die Herkunft eines
-ADR vorsieht und sein Template es führt. ADR-010 musste seine Herkunft deshalb in
-der Prosa des Context-Abschnitts tragen.
+Beim Schreiben von ADR-010 konnte `derived_from` nicht gesetzt werden:
+`metamodel/artifact.schema.yaml` hat `additionalProperties: false` und kennt das
+Feld nicht, obwohl der `adr`-Skill es für die Herkunft eines ADR vorsieht und
+sein Template es führt. Die Herkunft landete deshalb in der Prosa des
+Context-Abschnitts.
 
-Entweder das Schema zieht nach, oder der Skill sollte sagen, dass `derived_from`
-optional ist und ein Projekt es weglassen darf. Aktuell widersprechen sich
-Template und Schema stillschweigend.
+Wir hielten das zunächst für einen Widerspruch im Toolkit zwischen Template und
+Schema. Der Vergleich zeigte das Gegenteil: das Toolkit-Schema *hat*
+`derived_from` seit Zeile 83. Unsere Kopie hat es nicht.
 
-*Stromaufwärts noch nicht erfasst.* Wir vermuteten, der Befund existiere bereits
-aus einem anderen Projekt, und durchsuchten die Issues des Toolkits nach
-`derived_from` und `schema`: kein Treffer, der ihn beschreibt. Das nächstgelegene
-ist docs-as-code-toolkit#48 „Replace partial artifact metadata validation with
-full JSON Schema validation" — das betrifft die *Tiefe* der Validierung, nicht
-den Widerspruch zwischen Template und Schema. Ein Feld, das das Schema gar nicht
-kennt, wird auch von vollständiger Schema-Validierung nicht erlaubt; #48 löst
-diesen Punkt also nicht mit. Das Issue ist anzulegen.
+Die Abweichung geht in beide Richtungen. Unsere Kopie ergänzt `QualityGoal` und
+`priority` — lokale Erweiterungen, die es stromaufwärts nicht gibt. Und ihr
+fehlt der gesamte `derived_from`-Block, eine Toolkit-Ergänzung, die nie ankam.
+Das ist kein veraltetes Vendoring, sondern ein divergiertes.
+
+Damit ist es keine neue Erkenntnis, sondern eine zweite Instanz von
+docs-as-code-toolkit#26 „Define toolkit asset update mechanism for consuming
+projects". Das Issue nennt Metamodell-Schemata und „silently drift" wörtlich und
+ist selbst ein Slice von #22, wo die Drift schon einmal gefunden wurde. Der
+Beitrag dieses Projekts ist der Nachweis, dass sie auch bidirektional auftritt —
+ein reiner Update-Mechanismus, der stromabwärts überschreibt, würde hier lokale
+Erweiterungen zerstören.

--- a/diary/toolkit-validation.adoc
+++ b/diary/toolkit-validation.adoc
@@ -1,0 +1,54 @@
+== Toolkit validation
+
+Was die Anwendung des architecture-knowledge-toolkit bestätigt oder widerlegt
+hat. Ein Befund hier ist auch einen Issue stromaufwärts wert.
+
+=== Bestätigt: Slicing vor dem Implementieren trägt die Reihenfolge
+
+`slice-issues` erzeugte zehn Slices mit expliziter Abhängigkeitsordnung. Genau
+eine Abhängigkeit war tragend und wäre ohne das Slicing zu spät aufgefallen: die
+Fragmentregel (#52) musste vor dem CV (#56) liegen, weil erst sie zeigt, dass
+eine CV-Sprachvariante ein Alles-oder-nichts ist.
+
+Die übrigen Abhängigkeiten hätte man auch beim Arbeiten gemerkt. Die eine, die
+zählte, betraf ein Artefakt mit 90 Fragmenten — dort ist „beim Arbeiten merken"
+teuer.
+
+=== Bestätigt, durch Verletzung: der BDD-Default ist der richtige Default
+
+`bdd-specification` schreibt Szenarien als strikten Default für beobachtbares
+Verhalten vor, mit Ausweg nur über einen dokumentierten Waiver. Der Default wurde
+ab #49 stillschweigend ausgesetzt — nicht bewusst, sondern durch Wegrutschen.
+
+Der Nachzug (#65) kostete einen eigenen Slice und brachte drei Dinge ans Licht,
+die beim Mitschreiben nicht entstanden wären: ein Test, der zwei Szenarien
+abdeckte, drei Titel, die unpräziser waren als ihre Tests, und ein
+Kopfkommentar, der seit #51 nicht mehr stimmte.
+
+Bemerkt wurde die Lücke nicht durch das Werkzeug, sondern durch die Frage des
+Owners. Das ist der eigentliche Befund: der Skill formuliert den Default, aber
+nichts erzwingt ihn. Ein `check-scenarios`-Schritt analog zu
+`check-agent-adapters.js` wäre die naheliegende Ergänzung — allerdings untersagt
+der Skill ausdrücklich, im Zuge seiner Anwendung einen Runner zu bauen. Diese
+Spannung gehört stromaufwärts.
+
+=== Bestätigt: ADR-Review vor der Umsetzung fängt Widersprüche
+
+Der `adr`-Skill verlangt explizite Optionen und Review Notes vor der Annahme.
+Beim Review von ADR-010 verwarf der Owner die Fragment-Fallback-Regel — und das
+kollidierte mit einer früheren Festlegung im selben Dokument.
+
+Wäre der Widerspruch erst beim Implementieren aufgefallen, hätte die
+Stub-Generierung bereits existiert. So entfiel sie ersatzlos, bevor sie gebaut
+wurde.
+
+=== Offen: die Metamodell-Schemata kennen keine Provenienz
+
+`metamodel/artifact.schema.yaml` hat `additionalProperties: false` und kein
+`derived_from`, obwohl der `adr`-Skill genau dieses Feld für die Herkunft eines
+ADR vorsieht und sein Template es führt. ADR-010 musste seine Herkunft deshalb in
+der Prosa des Context-Abschnitts tragen.
+
+Entweder das Schema zieht nach, oder der Skill sollte sagen, dass `derived_from`
+optional ist und ein Projekt es weglassen darf. Aktuell widersprechen sich
+Template und Schema stillschweigend.

--- a/diary/toolkit-validation.adoc
+++ b/diary/toolkit-validation.adoc
@@ -52,3 +52,12 @@ der Prosa des Context-Abschnitts tragen.
 Entweder das Schema zieht nach, oder der Skill sollte sagen, dass `derived_from`
 optional ist und ein Projekt es weglassen darf. Aktuell widersprechen sich
 Template und Schema stillschweigend.
+
+*Stromaufwärts noch nicht erfasst.* Wir vermuteten, der Befund existiere bereits
+aus einem anderen Projekt, und durchsuchten die Issues des Toolkits nach
+`derived_from` und `schema`: kein Treffer, der ihn beschreibt. Das nächstgelegene
+ist docs-as-code-toolkit#48 „Replace partial artifact metadata validation with
+full JSON Schema validation" — das betrifft die *Tiefe* der Validierung, nicht
+den Widerspruch zwischen Template und Schema. Ein Feld, das das Schema gar nicht
+kennt, wird auch von vollständiger Schema-Validierung nicht erlaubt; #48 löst
+diesen Punkt also nicht mit. Das Issue ist anzulegen.

--- a/diary/working-agreements.adoc
+++ b/diary/working-agreements.adoc
@@ -31,3 +31,10 @@ Owner im Review, nicht beim Schreiben (#57).
 Fakten über fremde Laufbahn, Kunden und Projekte werden nicht erfunden, auch
 nicht als „erster Wurf".:: Kosten: keine — die Grenze wurde beim CV vor der
 Umsetzung gezogen (#56). Der Eintrag steht hier, damit sie gezogen bleibt.
+
+Ein Defekt in einem fremden Projekt wird in dessen Quellen geprüft, bevor er
+aufgeschrieben wird.:: Kosten: der `derived_from`-Befund war aus unserer Kopie
+des Toolkit-Schemas abgeleitet und beschrieb einen Widerspruch, den das Toolkit
+nicht hat. Ein `grep` in der fremden Datei hätte es widerlegt, bevor es im
+Tagebuch stand (docs-as-code-toolkit#26, #75).
+

--- a/diary/working-agreements.adoc
+++ b/diary/working-agreements.adoc
@@ -1,0 +1,33 @@
+== Working agreements
+
+Regeln, die entstanden sind, weil etwas schiefging. Keine Regel, die jemand
+vorgeschlagen hat. Jeder Eintrag ist eine Zeile plus die Kosten, die ihn erzeugt
+haben.
+
+Der gerenderte deutsche Output wird bei jeder Änderung gegen einen Build des
+vorherigen Standes verglichen.:: Kosten: ohne diesen Vergleich wären die
+`{ui_cv_subtitle}`-Literale auf drei Seiten und die stillschweigende Whitespace-
+Änderung jeder Seite unbemerkt live gegangen (#56, #55).
+
+Vor dem Vergleich wird die Vergleichsmethode selbst verifiziert — `main` zweimal
+bauen muss 0 Unterschiede ergeben.:: Kosten: ein stale Diff durch zsh
+`noclobber` führte zu einer halben Stunde Fehlersuche an einem Fehler, der nicht
+existierte (#49).
+
+Eine Regel, die zweimal auf dieselbe Art verletzt wurde, wird von einem Test
+erzwungen — nicht von einem Kommentar.:: Kosten: die Header-Falle (Leerzeile,
+Kommentarzeile, fehlendes Leerzeichen nach dem Doppelpunkt) hat zweimal
+zugeschlagen, bevor `test_link_registry_contains_only_attribute_entries`
+entstand (#49, #51).
+
+Ein Szenario entsteht mit dem Verhalten, nicht danach.:: Kosten: der Nachzug für
+vier Slices kostete einen eigenen Slice (#65), und drei Ungenauigkeiten wären
+beim Mitschreiben gar nicht erst entstanden.
+
+Generierte Prosa macht keine Mengenaussagen.:: Kosten: „1 weiterer Artikel" wäre
+falsch geworden, sobald die andere Sprache weniger Artikel hat — bemerkt vom
+Owner im Review, nicht beim Schreiben (#57).
+
+Fakten über fremde Laufbahn, Kunden und Projekte werden nicht erfunden, auch
+nicht als „erster Wurf".:: Kosten: keine — die Grenze wurde beim CV vor der
+Umsetzung gezogen (#56). Der Eintrag steht hier, damit sie gezogen bleibt.

--- a/progress/multilingual-site.adoc
+++ b/progress/multilingual-site.adoc
@@ -1,0 +1,67 @@
+= Mehrsprachige Site
+
+Die Seite soll jedes Artefakt auch in einer anderen Sprache tragen können, ohne
+dass Wiederverwendung und Fallback zu Handarbeit werden.
+
+*Status:* in flight — die Mechanik steht und läuft zweisprachig live; offen sind
+Diagrammquellen und die Übersetzung der inhaltsschweren Artefakte.
+
+== The plan
+
+Die Reihenfolge kam aus #47: erst das Metamodell, dann die Auflösungsklassen von
+innen nach außen, und die Pilotseite zuletzt — weil sie alles gleichzeitig prüft.
+
+[options="checklist"]
+* [x] Metamodell: Sprach- und Übersetzungsdimension — #48
+* [x] UI-Begriffe als Attribut-Kaskade mit Key-Parität — #49
+* [x] Sprach-Subtree `/en/` als Build-Target — #50
+* [x] Link-Registry statt harter Pfade — #51
+* [x] Content-Fragmente pro Sprache, Build-Abbruch bei Sprachmix — #52
+* [x] Artikel-Chrome und Listen pro Sprache — #53
+* [x] Übersetzungs-Provenienz und Drift-Hinweis — #54
+* [x] hreflang und Sprachumschalter — #55
+* [x] CV im Sprachmodell, PDF pro Sprache — #56
+* [x] Pilot: Home und Docs-as-Code-Artikel auf Englisch — #57
+* [x] BDD-Szenarien der Slices nachgezogen — #65
+* [ ] Sprachprüfung auf `plantuml::`-Quellen ausweiten — #70
+* [ ] Weitere Artefakte übersetzen — Autorenarbeit, kein Generatorthema
+
+Die Reihenfolge war an einer Stelle wirklich tragend: #52 (Fragmentregel) musste
+vor #56 (CV) liegen. Der CV zieht rund 90 Fragmente; ohne die Regel wäre nicht
+sichtbar gewesen, dass eine CV-Sprachvariante ein Alles-oder-nichts ist.
+
+== Where we are
+
+`/en/` ist live mit Startseite, Artikelübersicht, dem übersetzten
+Docs-as-Code-Artikel und den Listen. Ein Sprachumschalter (🇦🇹/🇬🇧) sitzt auf
+jeder Seite links von „Home". Verweise fallen auf Deutsch zurück und sagen es mit
+`(de)`; Fragmente fallen nicht zurück, sondern brechen den Build. Übersetzungen
+tragen eine Provenienz-Notiz mit Digest-basierter Frischeprüfung, die der Autor
+überschreiben kann.
+
+Der CV ist im Sprachmodell, aber nur auf Deutsch vorhanden: seine rund 90
+Fragmente sind echte Laufbahninhalte und damit Autorenarbeit.
+
+== Open in this topic
+
+* Welche Artefakte als nächstes übersetzt werden, und ob der CV das überhaupt
+  soll — die Fragmentregel macht ihn zu einem einzigen großen Schritt.
+* Ob Diagrammquellen unter `i18n/<lang>/` wandern oder mit Sprachsuffix neben
+  dem Artikel bleiben (#70 hält beide Varianten offen).
+* Ob ein Diagramm als sprachneutral markierbar sein soll — `doc-pipeline.puml`
+  ist bereits englisch und funktioniert in beiden Sprachen.
+
+== Checks
+
+Commands, not results. A number copied in here goes stale silently.
+
+[source,sh]
+----
+ruby scripts/validate-profile-metamodel.rb
+./gradlew buildSite
+for t in profile_language profile_cv_language profile_language_alternates \
+         profile_translation profile_navigation profile_listings \
+         profile_comments site_metadata_injector; do
+  ruby -Itest test/${t}_test.rb
+done
+----

--- a/skills/clock-in/SKILL.md
+++ b/skills/clock-in/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: clock-in
+description: Start a working session by establishing the real state of the repository and picking up a topic from progress/. Use at the beginning of a day, when resuming after an interruption, or when starting a new topic that will span more than one session.
+---
+
+# Clock In Skill
+
+## Purpose
+
+Resume a topic without depending on what anyone remembers.
+
+A session that starts by asking "where were we?" gets an answer built from
+memory, and memory is where this project's recorded mistakes come from. This
+skill starts from the repository instead, and only then asks the one question the
+repository cannot answer: which topic to work on.
+
+The counterpart is `skills/clock-out/SKILL.md`.
+
+## Steps
+
+**1. Establish the state before asking anything.**
+
+```sh
+git status --short && git branch --show-current
+git log --oneline -5
+gh pr list --state open
+gh issue list --state open --limit 20
+```
+
+Note anything that contradicts what the progress files will claim. Uncommitted
+work, a branch that is not `main`, an open pull request — these are facts about
+where the last session stopped, and they outrank any file.
+
+**2. List the topics from the directory, not from an index.**
+
+Every file in `progress/` is a topic. There is no index to go stale. For each
+one, take when it was last touched from git rather than from the file:
+
+```sh
+git log -1 --format='%ad %s' --date=short -- progress/<file>
+```
+
+**3. Ask, once, which topic to continue.** Offer each existing topic, plus
+starting a new one, plus working without a topic — a one-off fix does not need a
+progress file, and creating one for it is ceremony.
+
+Ask this as a single question. Do not pair it with a second one; the answers
+collide.
+
+**4. Read what the chosen topic depends on.**
+
+- `progress/<topic>.adoc` — the plan and where it stands.
+- The newest file in `diary/` — what the last session learned, which is often
+  why the plan says what it says.
+- The issues the plan references, if the plan's next step names any.
+
+**5. Report the delta, then start.** Three things, briefly: where the topic
+stands, what the plan's next step is, and what has changed on `main` since the
+file was last touched. If the two disagree, say so and fix the file — it
+describes now, so a stale statement in it is corrected on sight, not preserved.
+
+**6. For a new topic**, create `progress/<slug>.adoc` from
+`templates/progress.adoc` and fill the plan **with** the owner, not for them. A
+plan invented on their behalf is a guess wearing a checklist.
+
+## What a progress file is for
+
+It is the plan and the current status of one topic, sitting next to the code and
+present the moment the repository is checked out. That is what it adds over the
+issue board: an order of work, and the reason for that order, which a board
+cannot show.
+
+It refers to issues by number and never restates them. The issue owns the
+acceptance criteria; the file owns the sequence.
+
+It carries no history. It describes now, is rewritten as often as needed, and is
+deleted when its topic ends — what was learned along the way is in the diary by
+then.
+
+**No number in it that a command can produce.** Not test counts, not coverage,
+not bundle sizes. Write the command instead. A number copied into a file nobody
+re-runs is a claim that goes stale silently, and this repository has a
+through-line documenting where that leads.
+
+## When this skill should be deleted
+
+The ritual is general; `progress/`, AsciiDoc, and the diary wiring are this
+project's. If the toolkit ships a session-handoff skill, this file keeps only the
+project-specific paths and defers the rest.
+
+## Supporting files
+
+- `templates/progress.adoc` — the shape of a progress file. The only copy;
+  `clock-out` references this one.

--- a/skills/clock-in/templates/progress.adoc
+++ b/skills/clock-in/templates/progress.adoc
@@ -1,0 +1,39 @@
+= <Topic>
+
+<One sentence: what this topic is, in the owner's words.>
+
+*Status:* <in flight | on ice since <YYYY-MM-DD>> — <why, and what would bring
+it back>
+
+== The plan
+
+The intended order of the work, and the reason for that order. This is what the
+issue board cannot show.
+
+[options="checklist"]
+* [x] <a step a check confirmed>
+* [ ] <the next step> — <#issue, if one exists>
+* [ ] <a later step, with what it waits on>
+
+<A short paragraph where the order is not obvious: what has to come first, and
+what breaks if it does not.>
+
+== Where we are
+
+<Two or three sentences. What is built, what is decided, what the next session
+would otherwise have to reconstruct.>
+
+== Open in this topic
+
+<Questions and blockers that die when this topic ends. Anything that outlives it
+belongs in diary/open-threads.adoc instead.>
+
+== Checks
+
+Commands, not results. A number copied in here goes stale silently.
+
+[source,sh]
+----
+./gradlew validateProfileMetamodel
+./gradlew buildSite
+----

--- a/skills/clock-out/SKILL.md
+++ b/skills/clock-out/SKILL.md
@@ -52,7 +52,7 @@ A session does not end tidily just because it stopped.
 
 **3. Write the diary entry.** Follow `skills/diary/SKILL.md` — it owns what the
 entry contains, where it goes, and which of the cross-cutting documents must grow
-today.
+today. `skills/language-profile/SKILL.md` profile 5 owns how it reads.
 
 Write it from the commit history, the issues and the pull requests. At clock-out
 the day is fresh, which is exactly when memory feels reliable enough to skip the

--- a/skills/clock-out/SKILL.md
+++ b/skills/clock-out/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: clock-out
+description: End a working session by refreshing the progress files for the topics touched and writing the diary entry for the day. Use when the owner calls it a day, before a long break, or when a topic is being put on ice.
+---
+
+# Clock Out Skill
+
+## Purpose
+
+Leave the repository in a state that a session tomorrow can resume from without
+asking anyone.
+
+Two artifacts, and the split between them is the whole point:
+
+- `progress/<topic>.adoc` — **where we are.** Present tense, rewritten wholesale,
+  no history.
+- `diary/YYYY-MM-DD-<slug>.adoc` — **what we learned.** Past tense, never
+  revised once the day is closed.
+
+A sentence that fits both is a duplicate. It goes in the diary, because that is
+the one that may not be rewritten later.
+
+The counterpart is `skills/clock-in/SKILL.md`.
+
+## Steps
+
+**1. Close the loop on the work itself.** Nothing uncommitted without a reason
+stated, every open pull request named with its check status, every red check
+named. Take these from the tools, not from what happened in the session:
+
+```sh
+git status --short
+gh pr list --state open
+gh pr checks <number>
+```
+
+A session does not end tidily just because it stopped.
+
+**2. Refresh the progress file for every topic touched.**
+
+- Overwrite it. It describes now; there is nothing in it worth preserving as
+  history.
+- Move the plan's steps to their real state, and correct the plan itself if the
+  day showed the order was wrong. The plan is the thing worth having — a
+  checklist that no longer reflects the intended order is worse than none.
+- **Do not mark a step done that no check confirmed.** "Done" in a file that
+  outlives the session is a claim, and it will be believed.
+- If the topic is going on ice, say so in the status line together with **why**
+  and what would bring it back. "Paused" without a resumption condition is a file
+  nobody will ever reopen.
+- If the topic ended, delete the file. What it was for is in the diary by then.
+
+**3. Write the diary entry.** Follow `skills/diary/SKILL.md` — it owns what the
+entry contains, where it goes, and which of the cross-cutting documents must grow
+today.
+
+Write it from the commit history, the issues and the pull requests. At clock-out
+the day is fresh, which is exactly when memory feels reliable enough to skip the
+check.
+
+**4. Close the day, or do not.** A day file is open until the day is closed and
+append-only afterwards. Say plainly which of the two just happened, so that a
+later session knows whether it may still edit the file.
+
+**5. Say what is open — in the files, not only in the conversation.** The chat
+is gone tomorrow. A thread that outlives its topic goes to
+`diary/open-threads.adoc`; one that dies with the topic stays in the progress
+file.
+
+## What this skill does not do
+
+- It does not decide whether work is finished. Checks and reviews do that.
+- It does not merge, push to `main`, or close issues to make a day look complete.
+- It does not restate the commit format or the pull-request workflow. Those are
+  the toolkit's.
+
+## When this skill should be deleted
+
+The ritual is general; the two artifacts and their paths are this project's. If
+the toolkit ships a session-handoff skill, this file keeps only the
+project-specific parts and defers the rest.
+
+## Supporting files
+
+- `../clock-in/templates/progress.adoc` — the shape of a progress file. One copy,
+  deliberately, so the two skills cannot drift apart.

--- a/skills/diary/SKILL.md
+++ b/skills/diary/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: diary
+description: Write or extend a development diary entry. Use when recapping a working day, when a mistake is worth recording, when a working agreement emerges from something going wrong, when a thread is left deliberately unfinished, or when the toolkit's guidance is confirmed or contradicted by using it.
+---
+
+# Diary Skill
+
+## Purpose
+
+The diary records **why a wrong belief was plausible**. That is its whole reason
+to exist, and every rule below follows from it.
+
+It is not architecture documentation. Decisions live in
+`src-content/docs/arc42/09-architecture-decisions/`, constraints in
+`src-content/docs/arc42/doc-02000-architecture-constraints.adoc`, and those are the authority. The diary
+is the reasoning that did not fit in an ADR and the mistakes an ADR has no place
+to record.
+
+This skill owns **what an entry contains and where it goes**.
+
+How it *reads* is owned by a `language-profile` skill in the project this was
+taken from, profile 5 "Never revised". That skill is not in this repository yet.
+Until it is, the register rules that matter here are in `Lifecycle` below: a
+closed entry records what we believed at the time, so it is neither softened nor
+mocked in hindsight.
+
+## What belongs here, and what does not
+
+| It goes in | When it is |
+|---|---|
+| The diary | Something we believed, and what corrected it |
+| An ADR | A decision that binds future work |
+| `src-content/docs/doc-005-questions-and-answers.adoc` | A question the owner answered |
+| A GitHub issue | Work not yet done |
+| `progress/<topic>.adoc` | Where a topic stands right now |
+
+The last row is the one that slips. The diary is what we **learned**; a progress
+file is where we **are**. A sentence that fits both is a duplicate, and the diary
+keeps it, because it is the one that may not be rewritten later.
+
+## The day file
+
+One file per working day: `diary/YYYY-MM-DD-<slug>.adoc`, where the slug names
+what the day turned on rather than what was worked on — `domain-model`,
+`green-lights`, `features-and-identity`.
+
+- Heading: `== Day <n> — <D Month YYYY>: <what the day turned on>`.
+- Include it in `diary/diary.adoc` in date order. The cross-cutting documents
+  bracket the chronological ones: the through-line first, the toolkit validation
+  last.
+- Sections are `===` headings that state a finding, not a topic. "The figure that
+  was answering a different question", not "Calculator work".
+
+## Lifecycle
+
+**A day file is open until the day it covers is closed. After that, append
+only.**
+
+- While the day is open, edit freely. It is a draft.
+- Once closed, what we believed and when it is fixed. How it reads may still
+  change — voice, typography, a cross-reference, a corrected commit id.
+- Changing a past claim, softening a past error, or deleting an entry is
+  forbidden. That becomes a new entry, which may say the earlier one was wrong.
+
+This section is the rule itself. Once a `language-profile` skill exists here, the
+register consequences belong there and must not be restated in both places.
+
+## The four cross-cutting documents
+
+Each grows for exactly one reason. Adding to the wrong one is how they stop being
+readable.
+
+`diary/through-line.adoc`:: A new instance of the single lesson these days keep
+teaching, or a new category of it. An instance carries the artifact, what it
+claimed, and what would have caught it. Do not add an instance that only
+resembles one already there — resemblance is the point of the document, and it
+dilutes with volume.
+
+`diary/working-agreements.adoc`:: A rule that emerged because something went
+wrong. Never a rule someone proposed. Each entry is one line plus the cost that
+produced it.
+
+`diary/open-threads.adoc`:: A thread left deliberately unfinished, with the
+reasoning attached so the next decision does not start from scratch. A thread
+belongs here when it **outlives the topic that produced it**; if it dies with the
+topic, it belongs in that topic's progress file.
+
+`diary/toolkit-validation.adoc`:: The toolkit's guidance confirmed or
+contradicted by using it. This is the return on the project's second goal, so a
+finding here is worth an upstream issue as well.
+
+## Sourcing
+
+Written from the commit history, the issues and the pull requests — **never from
+memory**. Every date, number, issue id, commit id and quoted output is
+reproducible by a reader with the repository.
+
+Before writing, look at what actually happened:
+
+```sh
+git log --oneline --since=<date>
+gh pr list --state merged --limit 10
+gh issue list --state all --limit 20
+```
+
+A number that no command produced does not go in. This project has one recorded
+case of a constant that was invented by being reported as discovered; the rule
+comes from there.
+
+## When this skill should be deleted
+
+The diary practice is general and would suit any project that keeps one; the four
+cross-cutting documents and their split are this project's. If the toolkit ever
+ships a diary skill, this file keeps only the document list and defers the rest.

--- a/skills/diary/SKILL.md
+++ b/skills/diary/SKILL.md
@@ -16,13 +16,8 @@ It is not architecture documentation. Decisions live in
 is the reasoning that did not fit in an ADR and the mistakes an ADR has no place
 to record.
 
-This skill owns **what an entry contains and where it goes**.
-
-How it *reads* is owned by a `language-profile` skill in the project this was
-taken from, profile 5 "Never revised". That skill is not in this repository yet.
-Until it is, the register rules that matter here are in `Lifecycle` below: a
-closed entry records what we believed at the time, so it is neither softened nor
-mocked in hindsight.
+This skill owns **what an entry contains and where it goes**. How it *reads* is
+`skills/language-profile/SKILL.md`, profile 5 — read it before writing.
 
 ## What belongs here, and what does not
 
@@ -62,8 +57,8 @@ only.**
 - Changing a past claim, softening a past error, or deleting an entry is
   forbidden. That becomes a new entry, which may say the earlier one was wrong.
 
-This section is the rule itself. Once a `language-profile` skill exists here, the
-register consequences belong there and must not be restated in both places.
+The register consequences of this rule are in `language-profile` profile 5. This
+section is the rule itself; do not restate it there.
 
 ## The four cross-cutting documents
 

--- a/skills/language-profile/SKILL.md
+++ b/skills/language-profile/SKILL.md
@@ -1,0 +1,293 @@
+---
+name: language-profile
+description: Choose the register a document is written in before writing it. Use when writing or revising an ADR, architecture constraint, quality scenario, risk, glossary entry, arc42 chapter, README, AGENTS.md, a local skill, the questions-and-answers document, a progress file, a diary recap, a GitHub issue, a pull request body, a commit message, a code comment, or a Gherkin specification.
+---
+
+# Language Profile Skill
+
+## Purpose
+
+Project-specific addition covering one thing: the *register* each artifact here is
+written in.
+
+The toolkit's skills decide what an artifact must **contain** and what may happen
+to it. This skill decides how it **reads**. The two never overlap: if a rule is
+about structure, required sections, metadata, relations, status or lifecycle, it
+belongs to the toolkit and not here.
+
+It exists because the differences are load-bearing rather than stylistic. An ADR
+that hedges has decided nothing. A diary entry that mocks a past belief destroys
+the record of why the belief was plausible, which is the stated reason the diary
+exists.
+
+## Read first
+
+This skill adds voice rules to existing workflows. Read the baseline before
+applying it, and do not re-derive from here what those sources already say —
+resolve the toolkit skills through the lookup order in `AGENTS.md`:
+
+- the toolkit's `skills/adr`, `skills/risk`, `skills/quality-scenario`
+- the toolkit's `skills/commit-message` — **owns the commit format entirely.**
+  This skill adds nothing to it.
+- the toolkit's `skills/pr-review` and `skills/bdd-specification`
+- `general-semantic-contracts.md`
+
+## Picking a profile
+
+Not by formal against informal. That is a social axis and it predicts none of the
+rules below. Pick by **what the lifecycle does with the text once it turns out to
+be wrong**:
+
+| Fate under the lifecycle | Artifacts | Profile |
+|---|---|---|
+| Decision core fixed once accepted; a changed decision becomes a new record | ADR, architecture constraint | [1](#1-decided-once) |
+| Reassessed in place as evidence arrives | Risk, quality scenario | [2](#2-reassessed-in-place) |
+| Corrected in place, silently | Glossary, arc42 chapters, component descriptions, README, `AGENTS.md`, `general-semantic-contracts.md`, `ai-contracts/**`, `skills/**`, `progress/**` | [3](#3-corrected-silently) |
+| Corrected in place, visibly | `src-content/docs/doc-005-questions-and-answers.adoc` | [4](#4-corrected-visibly) |
+| Never revised | `diary/**` | [5](#5-never-revised) |
+| Corrected when a claim fails | Issue, pull request body, commit message | [6](#6-working-traffic) |
+| Changes with the code | Code comment, Gherkin feature | [7](#7-code-and-specifications) |
+
+An author who knows the core of a text is fixed writes differently from one who
+knows it will be re-judged next month. That difference is what the profiles
+encode.
+
+Fate picks the register. It does not pick the sentences: two artifacts can share
+a fate and still have different fields to fill, which is why a profile may carry
+sub-rules per artifact type. Where it does, the shared part is the register and
+the sub-rules are the vocabulary.
+
+**The first column is a reading of the toolkit's lifecycle, not a rule issued
+here.** It is the diagnostic used to pick a register, nothing more. This skill
+never says whether an artifact may be edited, superseded, re-graded or retired —
+the toolkit's `adr`, `risk` and `quality-scenario` skills say that, and if the
+column ever contradicts them, they are right and the column is stale.
+
+Published profile content — articles, shorts, the CV, the site chrome — is **not**
+in this table. Its voice is the author's and is product work, not a register this
+skill assigns.
+
+## Across every profile: naming a registered identifier
+
+One rule holds in all seven, because it is about how a sentence reads rather than
+what happens to it later.
+
+**When prose names something the build can resolve, write the identifier in
+backticks.** `translation_of`, not "the translation field". `ART-003-doc-as-code`,
+not "the Docs-as-Code article". `{url_cv_marker}`, `buildSite`,
+`generateProfileArtifacts`, `.article-list-languages`.
+
+The marking is what makes these sentences readable. This repository mixes English
+prose with German content and with identifiers that are neither, so a bare
+`ui_nav_home` in a sentence reads as though the author slipped. Marked, it reads
+as a name — and a reader who does not recognise it knows exactly what to grep for.
+
+Two things are not this:
+
+- **Quoting a rendering in order to reject it.** "'1 weiterer Artikel' is wrong as
+  soon as the other language has fewer" is prose about a wording, not a use of an
+  identifier. Quotation marks, not backticks.
+- **Example data.** `docs-as-code` as a tag value in a sentence about tagging is a
+  value, not a concept in the register.
+
+## 1. Decided once
+
+ADR, architecture constraint.
+
+Read by someone deciding years later whether this still applies, who was not
+present when it was decided.
+
+- **Name the deciding role and the date.** The role, not the person: owner,
+  architect. A decision whose author is unrecoverable cannot be re-judged.
+- **Active voice.** "It was decided", "es wurde entschieden" and their relatives
+  are forbidden. They are the construction that makes a decision unattributable.
+- **No hedging.** The Decision section says what holds, not what might be worth
+  considering. "We could perhaps" is not a decision.
+- **No blame.** Attribute the decision, never the error.
+- **Self-contained.** Reference sibling artifacts by ID; do not restate them. A
+  reader must not need the conversation that produced it.
+- **Record the rejected alternative and why**, or it gets proposed again with its
+  refutation invisible. ADR-010's Pugh matrix is the shape: four options, scored,
+  with a paragraph saying why the runners-up lost.
+- Present tense for the rule, past tense for the history.
+
+Metadata and traceability upkeep on an accepted record — a relation added, an
+evidence path corrected, a status moved — is the toolkit's business and is not a
+rewrite of the decision. The rules above govern the decision's *prose*.
+
+## 2. Reassessed in place
+
+Risk, quality scenario.
+
+Read by someone asking whether the claim still holds — usually the person who
+then has to re-judge it.
+
+Both artifacts share a fate and therefore a register. They do not share a
+vocabulary: a risk is graded, a scenario is specified, and the sub-rules below
+differ accordingly.
+
+**Shared:**
+
+- **Present tense, stating the claim that holds now.** Not the history of claims.
+- **Keep the claim and the evidence for it in separate sentences.** A number that
+  is simultaneously the requirement and the last measurement cannot be checked
+  against itself.
+- **When the claim moves, the prose under it moves with it.** A likelihood raised
+  while the paragraph justifying the old one stays put leaves two answers in one
+  artifact, and the reader cannot tell which is stale.
+- **Say what would move it**, so that someone other than the author can re-judge
+  it.
+
+**A risk** — `Likelihood`, `Impact`, `Priority`, `Timeframe`, `Confidence`:
+
+- **Attribute the evidence, not a decider.** Nobody decides a risk. A risk names
+  what the grade rests on.
+- **Assessment cells are terse; the reasoning goes below the table.** The
+  generated register inlines those cells into a narrow column, so a sentence there
+  is unreadable where it is actually consulted.
+
+**A quality scenario** — `Source`, `Stimulus`, `Artifact`, `Environment`,
+`Response`, `Response Measure`:
+
+- **The scenario as a whole describes one concrete, stageable occasion.** That is
+  the test the elements serve, and it is a property of the six read together.
+- **Each element writes what its own job needs.** `Source` names the actor.
+  `Stimulus` states what happens. `Artifact` names what is affected. `Environment`
+  states the operating condition that matters. `Response` says actively what the
+  system does.
+- **Three of the six are nominal and stay that way.** `Artifact`, `Environment`
+  and `Response Measure` name things and conditions. Demanding a verb there buys
+  nothing.
+- **The Response Measure is checkable without asking the author.** QS-004's is the
+  shape: "No backend call is required for core content display." "Fast enough" is
+  not a measure.
+- **A scenario carries no grade.** No likelihood, no priority, no confidence. The
+  metamodel has no place to put them, so an invented grade lands in prose and
+  reads as fact.
+
+Whether a threshold or a grade may move at all is not this skill's call.
+
+## 3. Corrected silently
+
+Glossary, arc42 chapter documents, component descriptions, README,
+`general-semantic-contracts.md`, `AGENTS.md`, `ai-contracts/**`, local skills
+under `skills/`, progress files under `progress/`.
+
+Read by someone who needs to act now.
+
+- **Present tense, describing what is.** No "we then decided to" — that is what an
+  ADR is for, and duplicating it means two artifacts own one truth.
+- **No dates in the body.** They go stale invisibly. The date belongs in the
+  frontmatter, or in a pin that names what it pins.
+- **Define once.** A term is defined in the glossary and linked from everywhere
+  else. Rationale lives in the ADR.
+- **State the exception where the rule is stated.** A convention documented in one
+  place and contradicted in another is how the `**/generated/` convention stopped being true
+  without anyone noticing.
+- README may carry voice; the glossary may not. That is a difference in density,
+  not in register.
+- **A progress file carries no number a command can produce.** Write the command
+  instead. This is `skills/clock-in/SKILL.md`'s rule; it appears here because it
+  is also what keeps the file readable.
+
+## 4. Corrected visibly
+
+`src-content/docs/doc-005-questions-and-answers.adoc`.
+
+Read by someone tracing why a decision reads the way it does.
+
+- **An answer that turns out wrong is not overwritten.** A dated correction is
+  added beneath it and the original stays legible.
+- Identifiers are permanent. A question keeps its id forever.
+- Say what the earlier answer claimed, not only what is now true. The point of
+  this document is the delta.
+
+## 5. Never revised
+
+`diary/**`.
+
+Read by us, later, looking for why a mistake was plausible.
+
+- **First person plural by default.** Use "I" only where the distinction carries
+  the lesson — where one of us proposed something and the other caught it, a
+  blanket plural hides who skipped the check.
+- Past tense.
+- **Unsparing about the error, generous about its plausibility.** Both halves are
+  required. Naming the mistake without explaining why it convinced anyone leaves a
+  record nobody can learn from.
+- **No cynicism.** Mocking a past belief deletes exactly what the entry is for.
+- Every claim checkable: dates, issue numbers, commit ids, quoted output.
+- **What we believed and when it is never revised; how it reads may be** — voice,
+  typography, a cross-reference. That is the register consequence of the diary's
+  lifecycle rule, which is `skills/diary/SKILL.md`'s and is not restated here.
+
+German is this project's working language with the owner, and the diary is
+written in it. The rules above are about register, not about which language the
+register is realised in.
+
+## 6. Working traffic
+
+Issue, pull request body, commit message.
+
+Read by a reviewer now, and by a stranger doing archaeology later.
+
+- Commit format is the toolkit's `commit-message` skill. Not restated here.
+- Say **why the change was worth making**, not what the diff already shows.
+- Acceptance criteria are checkable by someone who did not write them.
+- **Correct the claim, not only the code.** When a justification in an issue turns
+  out to be wrong, correct it there too — the issue text is what a later reader
+  finds first. Issue #56's acceptance criterion outlived the ADR review that
+  invalidated it, and the pull request had to say so.
+- **Report what was not reproduced.** A pull request that says a fix works is
+  weaker than one that says which four attempts to reproduce the fault failed.
+- Do not sell. A body that overstates what a change achieves is a claim nobody
+  will ever re-run.
+
+## 7. Code and specifications
+
+Code comments, Gherkin features.
+
+Read by whoever changes this next.
+
+- **Explain the non-obvious reason, never the what.** The comment above the
+  interface-term cascade explains why a file-existence check is impossible in
+  AsciiDoc; no reader could derive that from the include.
+- Match the density and idiom of the surrounding code.
+- **A scenario states behaviour, not mechanism.** Gherkin uses the reader's
+  vocabulary: "a link that falls back names the language it leads to", not "the
+  registry emits a marker attribute".
+- **A claim in a comment is a check nobody can run.** It gets the same scrutiny as
+  an assertion, or it does not get written.
+
+## Not covered here
+
+- **Published content.** Articles, shorts, the CV and the site chrome are the
+  author's voice and product work.
+- **Which language a page is written in.** That is ADR-010 and the profile
+  metadata, not a register.
+- **Commit message format.** The toolkit owns it.
+- **Lifecycle and ownership.** When an artifact may be edited, superseded or
+  re-graded belongs to whoever owns the artifact — the toolkit for everything it
+  defines, `skills/diary/SKILL.md` for the diary. Never this skill.
+- **What an entry contains and where it goes.** For the diary and the progress
+  files that is `skills/diary/SKILL.md`, `skills/clock-in/SKILL.md` and
+  `skills/clock-out/SKILL.md`.
+
+## When this skill should be deleted
+
+The *mechanism* — registers chosen by what the lifecycle does to a text — is
+general and belongs upstream if a second project confirms it. The *profiles* are
+this project's and do not.
+
+This is the second project to carry it, which is the first evidence that the
+mechanism travels. It is not yet evidence that the profiles do: the two projects
+adapted the table rather than sharing it. The upstream shape is therefore the
+mechanism plus a requirement that each project declare its own profiles.
+
+## Baseline
+
+Taken from the budget project's skill and adapted here. Written against toolkit
+`de7c2ad`. If the toolkit skills listed under [Read first](#read-first) have moved
+since, check that the delta above still only adds and never contradicts — in
+particular that the first column of the profile table still describes what those
+skills actually do.


### PR DESCRIPTION
Takes `clock-in`, `clock-out`, `diary` and `language-profile` from the budget project so a session can be handed over without relying on what anyone remembers, and runs the first clock-out with them.

The four are local for now and expected to move into the architecture-knowledge-toolkit. Each carries a `When this skill should be deleted` section saying what it keeps and what it defers once that happens.

## Not a copy

Paths were adapted to this repository, where architecture documentation sits under `src-content/docs`.

`language-profile` needed more than paths. The budget project writes its profiles against ADR-022 and ADR-023 and against examples from its own domain, none of which exist here. What travelled is the **mechanism** — pick a register by what the lifecycle does to a text once it turns out to be wrong — and the profile table was refilled from this project's artifacts: QS-004 as the shape of a checkable response measure, ADR-010's Pugh matrix as the shape of a recorded rejected alternative.

Two entries are this project's own:

* **Published content is deliberately not in the table.** Everything under `src-content/profile` carries the author's voice and is product work, not a register a tool assigns. Where that rule belongs instead — `write-article`, `article-summary-pack`, or both — is recorded as an open thread rather than decided.
* **Profile 3 gained a rule about stating an exception where the rule is stated.** That is what let the `**/generated/` convention become untrue without anyone noticing.

Being the second project to carry the skill is the first evidence that the mechanism travels and the profiles do not; the skill records that as the condition for offering it upstream.

## The clock-out itself

* `progress/multilingual-site.adoc` — the plan with its real state. Only steps a check confirmed are ticked. It records the one ordering that was load-bearing: #52 had to precede #56, because only the fragment rule shows that a CV language variant is all-or-nothing.
* `diary/2026-08-02-what-only-real-content-revealed.adoc` — written from commits, issues and pull requests.
* The four cross-cutting documents, each grown for its own reason.

## One finding was wrong, and the correction is the better entry

The clock-out first recorded a contradiction inside the toolkit: its `adr` skill asks for `derived_from`, its schema forbids it. Checking the toolkit's own schema showed the opposite — it has the field since line 83. **Our copy does not.**

The divergence runs both ways: our copy adds `QualityGoal` and `priority` and lacks the `derived_from` block. It is not stale but forked. That makes it a second instance of docs-as-code-toolkit#26 rather than a new finding, and the instance contributes something to that issue's design: an update mechanism that only pulls downstream would delete the local extensions. Reported there, tracked here as #75.

The day entry keeps the wrong belief and why it was plausible, and the working agreement that follows is recorded: a defect in another project is checked in that project's sources before it is written down.

## State

The day is **closed**; the day file is append-only from here. No open pull requests other than this one, `main` green, the site live in both languages.

Open afterwards: #70 (PlantUML language check), #64 (build heap), #74 (a merge can lose its deployment), #75 (schema reconciliation).