### PR TITLE
issue_77: Öffentliches Site-Target nur aus `published` rendern

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,8 @@ def publicArticleExclusions = { ->
             .execute(null, rootDir)
     process.waitForProcessOutput(stdout, stderr)
 
+    // Fail closed. Without a trustworthy list the safe answer is to render
+    // nothing, not to render everything.
     if (process.exitValue() != 0) {
         throw new GradleException(
                 'Could not determine which articles the public target may render.\n' +
@@ -125,6 +127,10 @@ def publicArticleExclusions = { ->
 
     stdout.toString().readLines().findAll { !it.trim().isEmpty() }.toSet()
 }()
+
+// The tasks that render article sources into a publishable target. Named once
+// so the validation contract below and its test refer to the same list.
+def publicRenderTasks = ['buildSite', 'buildArticlesDocbook']
 
 // The list holds repository-relative paths; a source spec matches relative to
 // its own source directory, so the directory prefix comes off again.
@@ -578,6 +584,70 @@ tasks.register('buildArticlesMarkdown', PandocDirectoryTask) {
     setOutputDirectory(layout.buildDirectory.dir("articles"))
 }
 
+// Checks the rendered result rather than the selection that produced it. The
+// source filter and this task fail independently: the filter decides what is
+// rendered, this asks whether anything unpublished ended up in the output
+// anyway. A build invoked in a way that bypassed the filter still fails here.
+// Asserts the contract itself rather than trusting it: every task that renders
+// article sources into a publishable target reaches metadata validation through
+// its dependencies. Checking the task graph rather than the build script text
+// means a dependency that moves still counts, and one that disappears does not.
+tasks.register('verifyPublicRenderTasksValidateMetadata') {
+    description = 'Fails when a task rendering article sources does not depend on profile metadata validation.'
+    group = 'verification'
+
+    doLast {
+        def required = tasks.named('validateProfileMetamodel').get()
+        def missing = publicRenderTasks.findAll { taskName ->
+            def start = tasks.named(taskName).get()
+            def seen = [start.path] as Set
+            def queue = [start]
+            def reached = false
+
+            while (!queue.isEmpty() && !reached) {
+                def current = queue.remove(0)
+                current.taskDependencies.getDependencies(current).each { dependency ->
+                    if (dependency.path == required.path) {
+                        reached = true
+                    } else if (seen.add(dependency.path)) {
+                        queue << dependency
+                    }
+                }
+            }
+
+            !reached
+        }
+
+        if (!missing.isEmpty()) {
+            throw new GradleException(
+                    'These tasks render article sources into a publishable target but do not depend on ' +
+                            "${required.path}, so they could render unvalidated metadata:\n- ${missing.join('\n- ')}")
+        }
+    }
+}
+
+tasks.register('verifyPublicTargetHasOnlyPublishedArticles') {
+    description = 'Fails when build/site or build/articles contains output of an article that is not published.'
+    group = 'verification'
+
+    dependsOn tasks.named('verifyPublicRenderTasksValidateMetadata')
+    mustRunAfter tasks.named('buildSite')
+    mustRunAfter tasks.named('buildArticlesMarkdown')
+
+    inputs.files(fileTree('src-content/profile') {
+        include '**/*.adoc'
+        include '**/*.profile.yaml'
+        exclude '**/generated/**'
+    })
+    inputs.files('scripts/validate-profile-metamodel.rb')
+
+    doLast {
+        exec {
+            commandLine 'ruby', 'scripts/validate-profile-metamodel.rb', '--verify-public-target-output'
+        }
+    }
+}
+
 tasks.register('verifyNoArticleSummariesInGeneratedOutputs') {
     mustRunAfter tasks.named('buildSite')
     mustRunAfter tasks.named('buildArticlesMarkdown')
@@ -620,6 +690,7 @@ tasks.register('verifyNoArticleSummariesInGeneratedOutputs') {
 
 tasks.named('buildArticlesMarkdown') {
     finalizedBy tasks.named('verifyNoArticleSummariesInGeneratedOutputs')
+    finalizedBy tasks.named('verifyPublicTargetHasOnlyPublishedArticles')
 }
 // CV
 asciidoctorBase('buildCVPersonal','','src-content/profile/cv', 'build/cv', ['cv.adoc'],true, 'pdf', [ // personal PDF (not deployed to the site)
@@ -682,6 +753,7 @@ tasks.named('buildSite') {
     }
 
     finalizedBy tasks.named('verifyNoArticleSummariesInGeneratedOutputs')
+    finalizedBy tasks.named('verifyPublicTargetHasOnlyPublishedArticles')
 }
 
 tasks.register('testSiteMetadata') {
@@ -722,6 +794,18 @@ tasks.named('buildCVSite') {
 // site page depends on it rather than only the article-level generated includes.
 tasks.named('buildSite') {
     dependsOn tasks.named('generateProfileArtifacts')
+}
+
+// Every task that renders article sources into a publishable target states its
+// dependency on metadata validation itself, rather than inheriting it through
+// generateProfileArtifacts. The publication selection is only as trustworthy as
+// the metadata behind it, and a transitive edge is one refactoring away from
+// disappearing without anything failing. verifyPublicRenderTasksValidateMetadata
+// asserts these edges, so removing one breaks a check rather than a guarantee.
+publicRenderTasks.each { taskName ->
+    tasks.named(taskName) {
+        dependsOn tasks.named('validateProfileMetamodel')
+    }
 }
 
 tasks.named('generateArchitectureArtifacts') {

--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,40 @@ def articleSummarySourceExcludes = [
         '**/*_summary_*.html'
 ]
 
+// Article sources the public target must not render, as repository-relative
+// paths. Ruby owns the metadata contract, so the selection is asked for rather
+// than reimplemented here.
+//
+// This runs while the build configures itself, not while it executes. The
+// Asciidoctor plugin resolves a task's source tree when it determines that
+// task's dependencies, which is before any generator has run: a list written
+// during the build would be missing exactly when a clean build needs it. That
+// is the same failure class as the article list pages that once pointed at a
+// mid-build directory, and configuration time removes it rather than ordering
+// around it.
+def publicArticleExclusions = { ->
+    def stdout = new StringWriter()
+    def stderr = new StringWriter()
+    def process = ['ruby', 'scripts/validate-profile-metamodel.rb', '--list-public-source-exclusions']
+            .execute(null, rootDir)
+    process.waitForProcessOutput(stdout, stderr)
+
+    if (process.exitValue() != 0) {
+        throw new GradleException(
+                'Could not determine which articles the public target may render.\n' +
+                        "ruby scripts/validate-profile-metamodel.rb --list-public-source-exclusions failed:\n${stderr}")
+    }
+
+    stdout.toString().readLines().findAll { !it.trim().isEmpty() }.toSet()
+}()
+
+// The list holds repository-relative paths; a source spec matches relative to
+// its own source directory, so the directory prefix comes off again.
+def excludeNonPublicArticles = { PatternFilterable spec, String sourceDir ->
+    publicArticleExclusions.findAll { it.startsWith("${sourceDir}/") }
+            .each { spec.exclude it.substring(sourceDir.length() + 1) }
+}
+
 tasks.register('checkEnvironment') {
     doLast {
         def missing = []
@@ -526,6 +560,16 @@ def articleSources = fileTree('src-content/profile/site/articles') {
 }.sort()
 
 asciidoctorBase('buildArticlesDocbook','','src-content/profile/site/articles', 'build/articles/docbook', articleSources,true, 'docbook', ['type': 'readme'])
+
+// The markdown export is a second rendering of the same article sources, and CI
+// uploads all of build/ as a workflow artifact. Filtering only build/site would
+// leave the full text of an unpublished article in a downloadable artifact of a
+// public repository, so the same metadata selection applies here.
+tasks.named('buildArticlesDocbook') {
+    sources {
+        excludeNonPublicArticles(delegate, 'src-content/profile/site/articles')
+    }
+}
 tasks.register('buildArticlesMarkdown', PandocDirectoryTask) {
     dependsOn tasks.named('buildArticlesDocbook')
     dependsOn tasks.named('buildArticlesDocbookCopyAssets')
@@ -611,6 +655,13 @@ tasks.named('buildSite') {
     inputs.file('scripts/inject-site-metadata.rb')
     inputs.property('siteBaseUrl', env('SITE_BASE_URL') ?: '')
     inputs.property('requireSiteBaseUrl', env('REQUIRE_SITE_BASE_URL', 'false'))
+
+    // The public site renders articles whose metadata says status: published.
+    // Any other status is absent from build/site, not merely absent from the
+    // listings, so an unpublished article has no reachable URL either.
+    sources {
+        excludeNonPublicArticles(delegate, 'src-content/profile/site')
+    }
 
     doLast {
         def command = [

--- a/features/article-publication-status.feature
+++ b/features/article-publication-status.feature
@@ -41,6 +41,31 @@ Feature: Article selection by publication status
     When the public article selection is computed
     Then the excluded path is the article source, not the sidecar
 
+  Scenario: A sidecar without a source field still names the article beside it
+    Given an unpublished article whose sidecar declares no source
+    When the public article selection is computed
+    Then the article file next to the sidecar is excluded
+
+  Scenario: An unresolvable source stops the selection instead of skipping the article
+    Given an unpublished article whose sidecar names a source file that is absent
+    When the public article selection is computed
+    Then the selection fails naming the article and its status
+
+  Scenario: A published article with an unresolvable source does not stop the selection
+    Given a published article whose sidecar names a source file that is absent
+    When the public article selection is computed
+    Then the selection succeeds and excludes nothing
+
+  Scenario: Output of an article the target must not contain is reported
+    Given a rendered target holding a page and an export of an unpublished article
+    When the rendered target is checked
+    Then both outputs are reported
+
+  Scenario: A rendered target holding only published output is accepted
+    Given a rendered target holding the page of a published article only
+    When the rendered target is checked
+    Then nothing is reported
+
   Scenario: Only published articles appear in public listings and navigation
     Given a published article and a preview article sharing a tag
     When the article listings and navigation are generated

--- a/features/article-publication-status.feature
+++ b/features/article-publication-status.feature
@@ -1,0 +1,62 @@
+# Living documentation for selecting article sources into a publication target.
+#
+# Bridged to: test/profile_publication_status_test.rb (classic Minitest, no
+# native BDD runner in this repository). Each scenario maps to a test method
+# named after the sanitized scenario title, with Given/When/Then comment anchors
+# inside it. Traceability is a reviewer-verifiable convention, not a
+# build-enforced link.
+#
+# The rule comes from ADR-008: the public target carries status published and
+# nothing else. Selection is by metadata rather than by location, so an article
+# is kept out of a target by what it says about itself. Absence here means the
+# page is not built at all - it has no URL, rather than merely no link.
+
+Feature: Article selection by publication status
+  As the owner of the profile publishing system
+  I want the public site to be selected from article metadata
+  So that an article is public because it says so, not because it exists
+
+  Scenario: A published article is rendered into the public target
+    Given an article whose status is published
+    When the public article selection is computed
+    Then its source is not excluded from the public target
+
+  Scenario: An article of any other status is kept out of the public target
+    Given articles with the statuses draft, proposed, preview, reviewed, private, archived, and deprecated
+    When the public article selection is computed
+    Then every one of their sources is excluded from the public target
+
+  Scenario: A language variant is selected on its own status
+    Given a published article and an unpublished translation of it
+    When the public article selection is computed
+    Then only the translation's source is excluded from the public target
+
+  Scenario: A page that is not an article is never excluded
+    Given a profile page and a short thought alongside an unpublished article
+    When the public article selection is computed
+    Then only the article's source is excluded from the public target
+
+  Scenario: Exclusions name the source file rather than the metadata file
+    Given an article whose metadata lives in a sidecar next to its source
+    When the public article selection is computed
+    Then the excluded path is the article source, not the sidecar
+
+  Scenario: Only published articles appear in public listings and navigation
+    Given a published article and a preview article sharing a tag
+    When the article listings and navigation are generated
+    Then the preview article appears in neither
+
+  Scenario: A published article may not point at an unpublished part of its series
+    Given a published article whose next article is still a draft
+    When the profile metadata is validated
+    Then validation fails naming both articles and the draft status
+
+  Scenario: An article sidecar that does not name its source stops the build
+    Given an article sidecar without a source field
+    When the profile metadata is validated
+    Then validation fails naming the sidecar
+
+  Scenario: An article sidecar whose source does not exist stops the build
+    Given an article sidecar naming a source file that is absent
+    When the profile metadata is validated
+    Then validation fails naming the sidecar

--- a/progress/article-lifecycle.adoc
+++ b/progress/article-lifecycle.adoc
@@ -1,0 +1,69 @@
+= Artikel-Lebenszyklus privat nach öffentlich
+
+Ein Artikel soll entstehen, reviewt und veröffentlicht werden können, ohne dass
+ein Entwurf allein dadurch öffentlich wird, dass er im Repository liegt.
+
+*Status:* in flight — Canonical-URLs stehen, die Statusauswahl ist umgesetzt und
+liegt als PR vor. Danach ist das Schreiben eines Entwurfs im öffentlichen
+Repository gefahrlos.
+
+== The plan
+
+Die Reihenfolge kommt aus #26 und aus einem Gate: ADR-008 ist akzeptiert,
+ADR-009 ist `proposed`. Alles, was private Quellen liest, Promotion automatisiert
+oder ein privates Target baut, wartet auf dessen Review.
+
+[options="checklist"]
+* [x] Canonical-URLs aus Basis-URL und Ausgabepfad, Pflicht in Produktion — #26
+* [x] Navigation und Artikellisten aus Metadaten statt Handpflege — kam mit #47
+* [x] `preview` und `private` im Schema und im Validator-Enum
+* [ ] Öffentliches Target nur aus `published` — Renderauswahl aus Metadaten — #77
+* [ ] `build/site-preview` mit `noindex`, ohne Canonical — #78
+* [ ] Deployment und Basic-Auth-Betrieb für `preview.dieterbaier.eu` — #79
+* [ ] ADR-009 reviewen — hebt das Gate — #80
+* [ ] Danach: erste Promotion-Checks, Promotion-Skript, `build/site-private`,
+  `private.dieterbaier.eu` — noch nicht geschnitten, Zuschnitt hängt an #80
+
+Die Statusauswahl muss vor allem anderen liegen. Sie ist die einzige Stelle, an
+der ein Entwurf im öffentlichen Repository liegen kann, ohne veröffentlicht zu
+sein — und damit die Bedingung dafür, überhaupt einen neuen Artikel hier zu
+schreiben. Das Preview-Target baut darauf auf: es ist dieselbe Auswahl mit einer
+anderen Statusmenge.
+
+Das Gate trennt sauber. Alles bis einschließlich Preview arbeitet nur auf
+öffentlicher Quelle und ist von ADR-009 unabhängig.
+
+== Where we are
+
+Der Build fragt zur Konfigurationszeit beim Profil-Validator ab, welche
+Artikelquellen ein Target ausschließt; `PUBLIC_STATUSES` ist auf `published`
+verengt. Der Weg über eine während des Builds erzeugte Liste funktioniert nicht:
+die Asciidoctor-Task löst ihren Quellbaum schon beim Bestimmen der
+Task-Abhängigkeiten auf, also vor jedem Generator. Das ist dieselbe Fehlerklasse
+wie bei den Listenseiten und steht als Begründung im Crosscutting-Kapitel.
+
+Canonical-Injektion, Basis-URL-Pflicht und ihre Tests stehen seit dem
+Multilingual-Epic. Das Epic führte den Slice noch als offen; das ist korrigiert.
+
+== Open in this topic
+
+* Ob `reviewed` als Status überhaupt bleibt, wenn er weder öffentlich noch
+  privat etwas auswählt.
+* Wie ein Preview-Artikel im öffentlichen Repository davor geschützt wird,
+  versehentlich auf `published` gesetzt zu werden — der erste Promotion-Check
+  könnte hier ansetzen statt erst an der Repository-Grenze.
+* Ob `build/site-preview` ein eigener Gradle-Task ist oder derselbe Task mit
+  einer Statusmenge als Parameter.
+
+== Checks
+
+Commands, not results. A number copied in here goes stale silently.
+
+[source,sh]
+----
+ruby scripts/validate-profile-metamodel.rb
+./gradlew buildSite
+ruby -Itest test/site_metadata_injector_test.rb
+ruby -Itest test/profile_listings_test.rb
+ruby -Itest test/profile_navigation_test.rb
+----

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -16,8 +16,21 @@ class ProfileArtifactValidator
   PROPERTIES = %w[id type title status owner created updated published reviewed generated language translation_of translation_source_digest translation_divergence audience channels summary summary_de summary_en source tags skills previous next relations metadata_version].freeze
   TYPES = %w[ProfilePage Article ShortThought CV Project ProfessionalExperience Education Skill Contact ProfileFragment].freeze
   STATUSES = %w[draft proposed preview reviewed published private archived deprecated].freeze
-  # Statuses whose articles may appear as public "related article" suggestions.
-  PUBLIC_STATUSES = %w[published preview reviewed].freeze
+  # Which article statuses each publication target renders. The target decides
+  # what is built, not where a file sits in the tree, so an article is kept out
+  # of a target by its own metadata and by nothing else.
+  #
+  # 'public' is the deployment of dieterbaier.eu and carries 'published' only.
+  # The article-comment allowlist has always selected on that single status; a
+  # wider definition here meant the repository held two answers to "is this
+  # article public", and the stricter one was the one reaching an external
+  # system.
+  TARGET_STATUSES = {
+    'public' => %w[published].freeze
+  }.freeze
+  # Statuses whose articles are part of the public site: rendered, listed,
+  # navigable, and offered as related-article suggestions.
+  PUBLIC_STATUSES = TARGET_STATUSES.fetch('public')
   # Ubiquitous tags carry no discriminating meaning across articles. They are
   # ignored when computing related-article tag overlap, and the validator warns
   # when an article relies on them. Keep meaningful topical tags (for example
@@ -145,6 +158,38 @@ class ProfileArtifactValidator
     FileUtils.mkdir_p(output_path.dirname)
     output_path.write(JSON.pretty_generate({ 'schema_version' => 1, 'article_ids' => article_ids }) + "\n", encoding: 'UTF-8')
     output_path
+  end
+
+  # Artifacts as they are on disk, without validating them. The build asks for
+  # the publication selection while it configures itself, long before the
+  # validator task runs, and a metadata error must be reported by that task
+  # rather than by every Gradle invocation.
+  def scan_artifacts
+    scan
+  end
+
+  # The article sources a publication target must not render, as
+  # repository-relative paths.
+  #
+  # The build excludes rather than includes because the site tree holds more
+  # than articles: profile pages, the toolkit page, legal, shorts, and generated
+  # list pages carry no article status and must keep rendering. An include list
+  # would have to enumerate all of them and would silently drop whatever it
+  # forgot; an exclude list only ever names articles that metadata rules out.
+  #
+  # Language variants are separate artifacts with their own status, so a
+  # translation is selected on its own metadata and never inherits the status of
+  # the article it was translated from.
+  def excluded_article_sources(artifacts, target:)
+    allowed = TARGET_STATUSES.fetch(target) do
+      raise ArgumentError, "unknown publication target '#{target}'"
+    end
+
+    artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
+             .reject { |article| allowed.include?(article.metadata['status']) }
+             .map { |article| relative(article_source_path(article)) }
+             .uniq
+             .sort
   end
 
   # Generates the article listings from metadata: a "recent" include fragment
@@ -685,7 +730,31 @@ class ProfileArtifactValidator
         source = root.join(artifact.metadata['source'])
         errors << "#{relative(artifact.path)} source does not exist: #{artifact.metadata['source']}" unless source.exist?
       end
+
+      validate_article_source_resolvable(artifact)
     end
+  end
+
+  # An article kept out of a target is kept out by its resolved source path, so
+  # a path that resolves to nothing would let the article through the filter
+  # instead of stopping the build. A sidecar therefore has to say which file it
+  # describes; front matter is its own source and needs no declaration.
+  def validate_article_source_resolvable(artifact)
+    return unless artifact.metadata['type'] == 'Article'
+    return if artifact.path.extname == '.adoc'
+
+    if blank?(artifact.metadata['source'])
+      errors << "#{relative(artifact.path)} is an Article sidecar and must declare 'source'"
+      return
+    end
+
+    resolved = article_source_path(artifact)
+    return if resolved.file?
+    # An absent source is already reported by the shared source check; this only
+    # adds the case where the path exists but is not a file to render.
+    return unless resolved.exist?
+
+    errors << "#{relative(artifact.path)} source is not a file: #{artifact.metadata['source']}"
   end
 
   def validate_ids(artifacts)
@@ -863,6 +932,13 @@ class ProfileArtifactValidator
           errors << "#{relative(artifact.path)} field '#{field}' references unknown artifact '#{target}'"
         elsif referenced.metadata['type'] != 'Article'
           errors << "#{relative(artifact.path)} field '#{field}' must reference an Article, but '#{target}' is a #{referenced.metadata['type']}"
+        elsif PUBLIC_STATUSES.include?(artifact.metadata['status']) &&
+              !PUBLIC_STATUSES.include?(referenced.metadata['status'])
+          # The public site renders the series link but not its target, so the
+          # reader would follow it into a 404. Naming both sides here is what
+          # separates "still writing the next part" from a broken published page.
+          errors << "#{relative(artifact.path)} is #{artifact.metadata['status']} and declares #{field} '#{target}', " \
+                    "which is #{referenced.metadata['status']} and therefore not on the public site"
         end
       end
 
@@ -1808,7 +1884,8 @@ if $PROGRAM_NAME == __FILE__
     output: nil,
     article_comment_allowlist: nil,
     accept_translation: nil,
-    language_alternates: nil
+    language_alternates: nil,
+    list_public_source_exclusions: false
   }
   OptionParser.new do |parser|
     parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
@@ -1818,6 +1895,7 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--article-comment-allowlist PATH') { |value| options[:article_comment_allowlist] = value }
     parser.on('--accept-translation ID') { |value| options[:accept_translation] = value }
     parser.on('--language-alternates PATH') { |value| options[:language_alternates] = value }
+    parser.on('--list-public-source-exclusions') { options[:list_public_source_exclusions] = true }
   end.parse!
 
   root = options[:root]
@@ -1825,6 +1903,16 @@ if $PROGRAM_NAME == __FILE__
   output = options[:output] || 'src-content/profile/generated/profile-artifact-index.adoc'
 
   validator = ProfileArtifactValidator.new(root: root, profile_dir: profile_dir)
+
+  # Answers the build's question about publication selection and nothing else.
+  # It reports no findings and fails on no metadata error, because the build
+  # asks while it configures itself: a validation failure here would break every
+  # Gradle invocation instead of the validator task that owns that report.
+  if options[:list_public_source_exclusions]
+    puts validator.excluded_article_sources(validator.scan_artifacts, target: 'public')
+    exit(0)
+  end
+
   artifacts = validator.validate
   validator.report(artifacts)
   exit(1) unless validator.errors.empty?

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -56,6 +56,10 @@ class ProfileArtifactValidator
   ARTIFACT_ID_PATTERN = /\A[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*\z/
   TAG_PATTERN = /\A[A-Za-z0-9][A-Za-z0-9-]*\z/
 
+  # Raised when the publication selection cannot name the source of an article
+  # it has to exclude. It is deliberately fatal: see excluded_article_sources.
+  class UnresolvableArticleSource < StandardError; end
+
   Artifact = Struct.new(:path, :metadata, keyword_init: true)
   attr_reader :errors, :warnings, :root, :profile_dir
 
@@ -185,11 +189,53 @@ class ProfileArtifactValidator
       raise ArgumentError, "unknown publication target '#{target}'"
     end
 
-    artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
-             .reject { |article| allowed.include?(article.metadata['status']) }
-             .map { |article| relative(article_source_path(article)) }
-             .uniq
-             .sort
+    excluded = artifacts.select { |artifact| artifact.metadata['type'] == 'Article' }
+                        .reject { |article| allowed.include?(article.metadata['status']) }
+
+    unresolved = excluded.reject { |article| article_source_path(article).file? }
+    unless unresolved.empty?
+      # Fail closed. This selection is the only thing keeping an unpublished
+      # article out of the target, and an article whose source cannot be named
+      # cannot be kept out of anything. Continuing here would produce a list
+      # that looks complete and silently omits exactly the articles that must
+      # not be rendered, so the build stops instead.
+      named = unresolved.map do |article|
+        "#{relative(article.path)} (#{article.metadata['status']}) -> #{relative(article_source_path(article))}"
+      end.sort
+      raise UnresolvableArticleSource,
+            "cannot determine the source file of #{unresolved.length} article(s) that must be excluded " \
+            "from the '#{target}' target:\n  #{named.join("\n  ")}"
+    end
+
+    excluded.map { |article| relative(article_source_path(article)) }.uniq.sort
+  end
+
+  # Where a rendered target keeps the output of a given source tree.
+  # Article sources live below the site tree, so an article source is rendered
+  # into both the site and the markdown export and has to be checked in both.
+  RENDER_ROOTS = [
+    { source_dir: 'src-content/profile/site', output_dir: 'build/site', extension: '.html' },
+    { source_dir: 'src-content/profile/site/articles', output_dir: 'build/articles', extension: '.md' }
+  ].freeze
+
+  # Outputs present in a rendered target that belong to an article the target
+  # must not contain.
+  #
+  # This checks the result rather than the selection. Whatever the build did
+  # with the exclusion list — applied it, mis-applied it, or was invoked in a
+  # way that skipped it — an article that must not be public either has output
+  # here or it does not.
+  def unexpected_target_outputs(artifacts, target:, render_roots: RENDER_ROOTS)
+    excluded_article_sources(artifacts, target: target).flat_map do |source|
+      render_roots.filter_map do |render_root|
+        prefix = "#{render_root[:source_dir]}/"
+        next unless source.start_with?(prefix)
+
+        rendered = source.delete_prefix(prefix).sub(/\.adoc\z/, render_root[:extension])
+        candidate = root.join(render_root[:output_dir], rendered)
+        relative(candidate) if candidate.exist?
+      end
+    end.uniq.sort
   end
 
   # Generates the article listings from metadata: a "recent" include fragment
@@ -735,10 +781,13 @@ class ProfileArtifactValidator
     end
   end
 
-  # An article kept out of a target is kept out by its resolved source path, so
-  # a path that resolves to nothing would let the article through the filter
-  # instead of stopping the build. A sidecar therefore has to say which file it
-  # describes; front matter is its own source and needs no declaration.
+  # A sidecar says which file it describes. This is not what keeps the
+  # publication selection safe — `article_source_path` resolves a sidecar to the
+  # article beside it, and `excluded_article_sources` stops the build when it
+  # cannot resolve one. It is a separate rule: an article whose source is
+  # implicit is one rename away from describing a different file, and the
+  # metamodel treats `source` as the link between metadata and content.
+  # Front matter is its own source and needs no declaration.
   def validate_article_source_resolvable(artifact)
     return unless artifact.metadata['type'] == 'Article'
     return if artifact.path.extname == '.adoc'
@@ -1798,9 +1847,21 @@ class ProfileArtifactValidator
     target.relative_path_from(from_dir).to_s
   end
 
+  # The article file an artifact describes.
+  #
+  # A sidecar is named '<slug>.profile.yaml', so its article is found by
+  # dropping the whole '.profile.yaml' suffix. Replacing only the extension
+  # yields '<slug>.profile.adoc', a file that does not exist — and a selection
+  # built on a path that resolves to nothing excludes nothing, which is how a
+  # draft would reach a public target.
   def article_source_path(article)
     source = article.metadata['source']
     return root.join(source) if source.is_a?(String) && !source.empty?
+
+    basename = article.path.basename.to_s
+    if (slug = basename[/\A(.+)\.profile\.ya?ml\z/, 1])
+      return article.path.dirname.join("#{slug}.adoc")
+    end
 
     article.path.sub_ext('.adoc')
   end
@@ -1885,7 +1946,8 @@ if $PROGRAM_NAME == __FILE__
     article_comment_allowlist: nil,
     accept_translation: nil,
     language_alternates: nil,
-    list_public_source_exclusions: false
+    list_public_source_exclusions: false,
+    verify_public_target_output: false
   }
   OptionParser.new do |parser|
     parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
@@ -1896,6 +1958,7 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--accept-translation ID') { |value| options[:accept_translation] = value }
     parser.on('--language-alternates PATH') { |value| options[:language_alternates] = value }
     parser.on('--list-public-source-exclusions') { options[:list_public_source_exclusions] = true }
+    parser.on('--verify-public-target-output') { options[:verify_public_target_output] = true }
   end.parse!
 
   root = options[:root]
@@ -1909,8 +1972,34 @@ if $PROGRAM_NAME == __FILE__
   # asks while it configures itself: a validation failure here would break every
   # Gradle invocation instead of the validator task that owns that report.
   if options[:list_public_source_exclusions]
-    puts validator.excluded_article_sources(validator.scan_artifacts, target: 'public')
+    begin
+      puts validator.excluded_article_sources(validator.scan_artifacts, target: 'public')
+    rescue ProfileArtifactValidator::UnresolvableArticleSource => e
+      warn "Publication selection failed: #{e.message}"
+      exit(1)
+    end
     exit(0)
+  end
+
+  # Checks the rendered output rather than the selection that produced it, so
+  # the guarantee holds even for a build invoked in a way that skipped the
+  # selection.
+  if options[:verify_public_target_output]
+    begin
+      unexpected = validator.unexpected_target_outputs(validator.scan_artifacts, target: 'public')
+    rescue ProfileArtifactValidator::UnresolvableArticleSource => e
+      warn "Publication selection failed: #{e.message}"
+      exit(1)
+    end
+
+    if unexpected.empty?
+      puts 'Public target contains no output of a non-published article.'
+      exit(0)
+    end
+
+    warn "Public target contains output of #{unexpected.length} article(s) that are not published:"
+    unexpected.each { |path| warn "  - #{path}" }
+    exit(1)
   end
 
   artifacts = validator.validate

--- a/src-content/docs/arc42/10-quality-requirements/qs-005-publication-visibility-boundary.adoc
+++ b/src-content/docs/arc42/10-quality-requirements/qs-005-publication-visibility-boundary.adoc
@@ -48,4 +48,12 @@ xref:qg-004-correctness[QG-004: Correctness]
 
 === Assumptions
 
-The exact verification mechanism is still proposed. It may be implemented as a Gradle verification task that inspects generated HTML and the metadata-derived source set.
+The public half of the response measure is verified: `build/site` is rendered
+from a metadata-derived source set that carries `published` only, specified in
+`features/article-publication-status.feature` and bridged to
+`test/profile_publication_status_test.rb`.
+
+The preview and private half is not. Those targets do not exist yet, so the
+`noindex` and canonical-link part of the measure has nothing to verify against.
+The mechanism for it is still open and may become a Gradle verification task
+that inspects generated HTML.

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -43,6 +43,19 @@ during the build would be missing exactly when a clean build needs it.
 The same selection applies to the markdown export, since CI uploads the whole
 build directory as a workflow artifact of a public repository.
 
+The selection fails closed. An article that must be kept out of a target and
+whose source file cannot be named stops the build, because a list that silently
+omits such an article looks complete while leaving out exactly what must not be
+rendered.
+
+Two checks stand behind the selection rather than beside it.
+`verifyPublicRenderTasksValidateMetadata` asserts that every task rendering
+article sources reaches metadata validation through its dependencies, so the
+contract survives a refactoring instead of resting on a transitive edge.
+`verifyPublicTargetHasOnlyPublishedArticles` inspects the rendered result: an
+article that must not be public either has output there or it does not,
+whatever the build did with the selection.
+
 The observable behaviour is specified in
 `features/article-publication-status.feature` and bridged to
 `test/profile_publication_status_test.rb`.

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -27,6 +27,26 @@ Deployment credentials are scoped by target system. `PROFILE_REPO_TOKEN` grants 
 
 Metadata validation runs before documentation rendering. The architecture validator follows the architecture-knowledge-toolkit metamodel. The profile validator checks profile artifact metadata, relations, and generated indexes.
 
+== Publication Selection
+
+A publication target renders the article statuses that target allows, decided in
+ADR-008. The public target allows `published` and nothing else. An article of any
+other status is absent from `build/site` rather than merely absent from its
+listings, so it has no URL to reach.
+
+Selection is by article metadata, never by where a file sits, so an article is
+kept out of a target by what it says about itself. The build asks the profile
+validator which sources a target excludes while it configures itself, because a
+render task resolves its sources before any generator runs; a list produced
+during the build would be missing exactly when a clean build needs it.
+
+The same selection applies to the markdown export, since CI uploads the whole
+build directory as a workflow artifact of a public repository.
+
+The observable behaviour is specified in
+`features/article-publication-status.feature` and bridged to
+`test/profile_publication_status_test.rb`.
+
 == Observability
 
 CI logs, Gradle task output, and validator reports are the operational feedback loop.

--- a/test/profile_publication_status_test.rb
+++ b/test/profile_publication_status_test.rb
@@ -67,6 +67,22 @@ class ProfilePublicationStatusTest < Minitest::Test
     validator.excluded_article_sources(artifacts, target: 'public')
   end
 
+  # The temporary tree has no src-content/profile/site, so the render roots are
+  # named here instead of using the repository's own.
+  def test_render_roots
+    [
+      { source_dir: 'articles', output_dir: 'out/site', extension: '.html' },
+      { source_dir: 'articles', output_dir: 'out/articles', extension: '.md' }
+    ]
+  end
+
+  def write_output(root, relative_path)
+    path = root + relative_path
+    path.dirname.mkpath
+    path.write("rendered\n")
+    path
+  end
+
   def test_a_published_article_is_rendered_into_the_public_target
     # Given: an article whose status is published
     with_artifacts([{ id: 'ART-101-live', slug: 'live', status: 'published' }]) do |validator, artifacts, _root|
@@ -137,6 +153,87 @@ class ProfilePublicationStatusTest < Minitest::Test
       # Then: the excluded path is the article source, not the sidecar
       assert_equal ['articles/sidecar.adoc'], result
       refute_includes result.join("\n"), '.profile.yaml'
+    end
+  end
+
+  def test_a_sidecar_without_a_source_field_still_names_the_article_beside_it
+    # Given: an unpublished article whose sidecar declares no source
+    spec = [{ id: 'ART-1001-implicit', slug: 'implicit', status: 'draft', omit_source: true }]
+
+    with_artifacts(spec) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: the article file next to the sidecar is excluded
+      assert_equal ['articles/implicit.adoc'], result
+    end
+  end
+
+  def test_an_unresolvable_source_stops_the_selection_instead_of_skipping_the_article
+    # Given: an unpublished article whose sidecar names a source file that is absent
+    spec = [{ id: 'ART-1101-gone', slug: 'gone', status: 'draft', source: 'articles/not-here.adoc' }]
+
+    with_artifacts(spec) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      error = assert_raises(ProfileArtifactValidator::UnresolvableArticleSource) do
+        excluded(validator, artifacts)
+      end
+
+      # Then: the selection fails naming the article and its status
+      assert_includes error.message, 'gone.profile.yaml'
+      assert_includes error.message, 'draft'
+      assert_includes error.message, 'public'
+    end
+  end
+
+  def test_a_published_article_with_an_unresolvable_source_does_not_stop_the_selection
+    # Given: a published article whose sidecar names a source file that is absent
+    spec = [{ id: 'ART-1201-live', slug: 'live', status: 'published', source: 'articles/not-here.adoc' }]
+
+    with_artifacts(spec) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: the selection succeeds and excludes nothing
+      assert_empty result
+    end
+  end
+
+  def test_output_of_an_article_the_target_must_not_contain_is_reported
+    # Given: a rendered target holding a page and an export of an unpublished article
+    spec = [
+      { id: 'ART-1301-live', slug: 'live', status: 'published' },
+      { id: 'ART-1302-draft', slug: 'draft', status: 'draft' }
+    ]
+
+    with_artifacts(spec) do |validator, artifacts, root|
+      write_output(root, 'out/site/draft.html')
+      write_output(root, 'out/articles/draft.md')
+      write_output(root, 'out/site/live.html')
+
+      # When: the rendered target is checked
+      result = validator.unexpected_target_outputs(artifacts, target: 'public', render_roots: test_render_roots)
+
+      # Then: both outputs are reported
+      assert_equal ['out/articles/draft.md', 'out/site/draft.html'], result
+    end
+  end
+
+  def test_a_rendered_target_holding_only_published_output_is_accepted
+    # Given: a rendered target holding the page of a published article only
+    spec = [
+      { id: 'ART-1401-live', slug: 'live', status: 'published' },
+      { id: 'ART-1402-draft', slug: 'draft', status: 'draft' }
+    ]
+
+    with_artifacts(spec) do |validator, artifacts, root|
+      write_output(root, 'out/site/live.html')
+
+      # When: the rendered target is checked
+      result = validator.unexpected_target_outputs(artifacts, target: 'public', render_roots: test_render_roots)
+
+      # Then: nothing is reported
+      assert_empty result
     end
   end
 

--- a/test/profile_publication_status_test.rb
+++ b/test/profile_publication_status_test.rb
@@ -1,0 +1,209 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for selecting article sources into a
+# publication target.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in
+# features/article-publication-status.feature, with Given/When/Then comment
+# anchors separating Arrange, Act, and Assert. Each test builds an isolated
+# temporary profile tree so the real repository is never touched.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfilePublicationStatusTest < Minitest::Test
+  # Builds an isolated profile tree from lightweight artifact descriptions and
+  # yields a validated validator plus the profile root.
+  def with_artifacts(artifacts_spec)
+    Dir.mktmpdir('profile-status-test') do |dir|
+      root = Pathname.new(dir)
+
+      # Listing titles come from the interface terms, so every profile tree that
+      # generates listings needs them - the same contract the validator enforces.
+      (root + 'includes/i18n').mkpath
+      (root + 'includes/i18n/ui-de.adoc').write(
+        ":ui_article_list_all: Alle Artikel\n" \
+        ":ui_article_list_tag_prefix: Artikel mit dem Tag:\n" \
+        ":ui_article_list_skill_prefix: Artikel zum Thema:\n"
+      )
+
+      artifacts_spec.each do |spec|
+        slug = spec.fetch(:slug)
+        rel_dir = spec.fetch(:dir, 'articles')
+        (root + rel_dir).mkpath
+        source_rel = "#{rel_dir}/#{slug}.adoc"
+        (root + source_rel).write("= #{spec.fetch(:title, slug)}\n") unless spec[:omit_source_file]
+        (root + "#{rel_dir}/#{slug}.profile.yaml").write(metadata_yaml(spec, source_rel))
+      end
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield(validator, artifacts, root)
+    end
+  end
+
+  def metadata_yaml(spec, source_rel)
+    metadata = {
+      'id' => spec.fetch(:id),
+      'type' => spec.fetch(:type, 'Article'),
+      'title' => spec.fetch(:title, spec.fetch(:slug)),
+      'status' => spec.fetch(:status, 'published'),
+      'owner' => 'Test Owner',
+      'created' => spec.fetch(:created, '2026-01-01')
+    }
+    metadata['source'] = spec.fetch(:source, source_rel) unless spec[:omit_source]
+    %i[language translation_of previous next tags].each do |key|
+      metadata[key.to_s] = spec[key] if spec.key?(key)
+    end
+    metadata.to_yaml
+  end
+
+  def excluded(validator, artifacts)
+    validator.excluded_article_sources(artifacts, target: 'public')
+  end
+
+  def test_a_published_article_is_rendered_into_the_public_target
+    # Given: an article whose status is published
+    with_artifacts([{ id: 'ART-101-live', slug: 'live', status: 'published' }]) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: its source is not excluded from the public target
+      assert_empty result
+    end
+  end
+
+  def test_an_article_of_any_other_status_is_kept_out_of_the_public_target
+    # Given: articles with every status the metamodel accepts besides published
+    statuses = ProfileArtifactValidator::STATUSES - ProfileArtifactValidator::PUBLIC_STATUSES
+    spec = statuses.each_with_index.map do |status, index|
+      { id: format('ART-2%02d-%s', index, status), slug: status, status: status }
+    end
+
+    with_artifacts(spec) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: every one of their sources is excluded from the public target
+      assert_equal statuses.map { |status| "articles/#{status}.adoc" }.sort, result
+    end
+  end
+
+  def test_a_language_variant_is_selected_on_its_own_status
+    # Given: a published article and an unpublished translation of it
+    spec = [
+      { id: 'ART-301-original', slug: 'original', status: 'published', language: 'de' },
+      { id: 'ART-301-original-en', slug: 'original', dir: 'en/articles', status: 'draft',
+        language: 'en', translation_of: 'ART-301-original' }
+    ]
+
+    with_artifacts(spec) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: only the translation's source is excluded from the public target
+      assert_equal ['en/articles/original.adoc'], result
+    end
+  end
+
+  def test_a_page_that_is_not_an_article_is_never_excluded
+    # Given: a profile page and a short thought alongside an unpublished article
+    spec = [
+      { id: 'PP-401-home', slug: 'home', dir: 'pages', type: 'ProfilePage', status: 'draft' },
+      { id: 'ST-402-thought', slug: 'thought', dir: 'shorts', type: 'ShortThought', status: 'draft' },
+      { id: 'ART-403-hidden', slug: 'hidden', status: 'draft' }
+    ]
+
+    with_artifacts(spec) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: only the article's source is excluded from the public target
+      assert_equal ['articles/hidden.adoc'], result
+    end
+  end
+
+  def test_exclusions_name_the_source_file_rather_than_the_metadata_file
+    # Given: an article whose metadata lives in a sidecar next to its source
+    with_artifacts([{ id: 'ART-501-sidecar', slug: 'sidecar', status: 'draft' }]) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      result = excluded(validator, artifacts)
+
+      # Then: the excluded path is the article source, not the sidecar
+      assert_equal ['articles/sidecar.adoc'], result
+      refute_includes result.join("\n"), '.profile.yaml'
+    end
+  end
+
+  def test_only_published_articles_appear_in_public_listings_and_navigation
+    # Given: a published article and a preview article sharing a tag
+    spec = [
+      { id: 'ART-601-live', slug: 'live', title: 'Live', status: 'published', tags: %w[shared] },
+      { id: 'ART-602-soon', slug: 'soon', title: 'Soon', status: 'preview', tags: %w[shared] }
+    ]
+
+    with_artifacts(spec) do |validator, artifacts, root|
+      # When: the article listings and navigation are generated
+      validator.generate_article_lists(artifacts)
+      validator.generate_article_navigation(artifacts)
+
+      listings = Dir.glob((root + 'articles/generated/lists/*.adoc').to_s).map { |path| File.read(path) }.join("\n")
+      navigation = (root + 'articles/generated/live-navigation.adoc')
+
+      # Then: the preview article appears in neither
+      refute_empty listings
+      refute_includes listings, 'soon.html'
+      refute_includes listings, 'Soon'
+      refute_includes(navigation.exist? ? navigation.read : '', 'soon.html')
+    end
+  end
+
+  def test_a_published_article_may_not_point_at_an_unpublished_part_of_its_series
+    # Given: a published article whose next article is still a draft
+    spec = [
+      { id: 'ART-701-part-one', slug: 'part-one', status: 'published', next: 'ART-702-part-two' },
+      { id: 'ART-702-part-two', slug: 'part-two', status: 'draft', previous: 'ART-701-part-one' }
+    ]
+
+    with_artifacts(spec) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated
+      errors = validator.errors
+
+      # Then: validation fails naming both articles and the draft status
+      matching = errors.grep(/part-one\.profile\.yaml/).grep(/ART-702-part-two/)
+      refute_empty matching, "expected a series status error, got: #{errors.inspect}"
+      assert_includes matching.first, 'draft'
+    end
+  end
+
+  def test_an_article_sidecar_that_does_not_name_its_source_stops_the_build
+    # Given: an article sidecar without a source field
+    with_artifacts([{ id: 'ART-801-nameless', slug: 'nameless', omit_source: true }]) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated
+      errors = validator.errors
+
+      # Then: validation fails naming the sidecar
+      matching = errors.grep(/nameless\.profile\.yaml/).grep(/must declare 'source'/)
+      refute_empty matching, "expected a missing-source error, got: #{errors.inspect}"
+    end
+  end
+
+  def test_an_article_sidecar_whose_source_does_not_exist_stops_the_build
+    # Given: an article sidecar naming a source file that is absent
+    spec = [{ id: 'ART-901-absent', slug: 'absent', omit_source_file: true }]
+
+    with_artifacts(spec) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated
+      errors = validator.errors
+
+      # Then: validation fails naming the sidecar
+      matching = errors.grep(/absent\.profile\.yaml/).grep(/source/)
+      refute_empty matching, "expected a missing-source-file error, got: #{errors.inspect}"
+    end
+  end
+end


### PR DESCRIPTION
Closes #77. First slice of #26.

## The gap

`buildSite` rendered every `.adoc` under `src-content/profile/site`, excluding only article-summary sources and `**/generated/**`. Article status reached listings and related entries (`scripts/validate-profile-metamodel.rb:1312`, `:1640`) but never the render selection, so an article with `status: draft` was built and deployed with a reachable URL — it was only missing from the listings.

`PUBLIC_STATUSES` was `published, preview, reviewed`, while the article-comment allowlist selected on `published` alone. The repository held two answers to "is this article public", and the stricter one was the one reaching an external system.

## What changed

**Selection by metadata.** `TARGET_STATUSES` maps a publication target to the statuses it renders; `public` carries `published`. `excluded_article_sources` returns the article sources a target must not render, and `--list-public-source-exclusions` exposes it to the build. `PUBLIC_STATUSES` is now derived from that map, so listings, navigation, and related entries follow the same single definition.

It excludes rather than includes because the site tree holds more than articles — profile pages, the toolkit page, legal, shorts, generated list pages. An include list would have to enumerate all of them and would silently drop whatever it forgot.

**Configuration time, not execution time.** The first version had `generateProfileArtifacts` write the exclusion list and the render task read it while walking its sources. That does not work: the Asciidoctor plugin resolves a task's source tree when it determines that task's dependencies, which is before any generator runs. A clean build failed with `Could not determine the dependencies of task ':buildSite'`. The build now asks Ruby for the selection while it configures itself, which has no intra-build ordering at all.

This is the same failure class as the article list pages that pointed at a directory created mid-build (see the day-2 diary entry). The fix follows the same principle: remove the ordering dependency rather than order around it.

**The markdown export too.** CI uploads all of `build/` as a workflow artifact of a public repository. Filtering only `build/site` would leave an unpublished article's full text downloadable, so `buildArticlesDocbook` gets the same selection. This is wider than #77's acceptance criteria, which name `build/site`; flagged here rather than done quietly.

**Two validator rules** for the ways the filter could pass something through silently:

- A `published` article may not declare `previous`/`next` pointing at an article that is not public. The site would render the link but not its target, so the reader follows it into a 404.
- An Article sidecar must declare a resolvable `source`. Selection works on the resolved source path; a path resolving to nothing would let the article through the filter instead of stopping the build.

**Architecture.** New crosscutting concept "Publication Selection" in `doc-08000`. QS-005 now says which half of its response measure is verified and which is not — the preview and private half has no target to verify against yet.

## Verification

`features/article-publication-status.feature` — 9 scenarios, bridged to 9 methods in `test/profile_publication_status_test.rb` by the sanitized-title convention.

End to end with a real draft article added to the tree:

| Same file, status | In `build/site` | In `build/articles` | Full-text grep over `build/` |
|---|---|---|---|
| `draft` | absent | absent | no match |
| `published` | present | present | matches |

Clean-tree runs (`build/site`, `build/articles`, and the Gradle daemon reset between runs), so the result does not depend on a generator having been run by hand first.

Green: all nine Ruby test files, both Node test files, `validateArchitectureMetamodel`, `validateProfileMetamodel`, `buildAll`.

Not reproduced as a defect of this change: `buildAll` failed once with `Metaspace` in `buildCVDownload` after many builds in one session. A fresh daemon builds green on this branch and on `main`; that is #64.

## Left open

- Whether `reviewed` stays a status now that it selects nothing in either direction.
- The preview status set, which is #78 and reuses `TARGET_STATUSES`.
