### PR TITLE
issue_80: ADR-009 akzeptieren und das Gate für private Quellen heben

### DIFF
--- a/src-content/docs/arc42/09-architecture-decisions/adr-008-private-to-public-article-lifecycle.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-008-private-to-public-article-lifecycle.adoc
@@ -104,7 +104,9 @@ participant "preview.dieterbaier.eu" as PreviewSite
 Author -> Promote : select article for preview
 Promote -> PrivateRepo : read article source and metadata
 Promote -> Promote : remove private-only material and set status preview
-Promote -> PublicRepo : copy source and sidecar metadata
+Promote -> Promote : validate against the public contract before moving
+Promote -> PublicRepo : move source and sidecar metadata in
+Promote -> PrivateRepo : remove the promoted article
 Author -> PublicRepo : review diff before push
 PublicRepo -> PreviewSite : build and deploy noindex preview
 Author -> PreviewSite : share rendered preview for feedback

--- a/src-content/docs/arc42/09-architecture-decisions/adr-008-private-to-public-article-lifecycle.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-008-private-to-public-article-lifecycle.adoc
@@ -104,8 +104,9 @@ participant "preview.dieterbaier.eu" as PreviewSite
 Author -> Promote : select article for preview
 Promote -> PrivateRepo : read article source and metadata
 Promote -> Promote : remove private-only material and set status preview
-Promote -> Promote : validate against the public contract before moving
-Promote -> PublicRepo : move source and sidecar metadata in
+Promote -> Promote : validate against the public contract before writing
+Promote -> PublicRepo : write source and sidecar metadata (leading side)
+note right: the article exists in both\nuntil the next step completes
 Promote -> PrivateRepo : remove the promoted article
 Author -> PublicRepo : review diff before push
 PublicRepo -> PreviewSite : build and deploy noindex preview

--- a/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
@@ -2,10 +2,10 @@
 id: ADR-009-private-repository-integration
 type: ADR
 title: "Private Repository Integration"
-status: proposed
+status: accepted
 owner: "Dieter Baier"
 created: '2026-07-07'
-reviewed: false
+reviewed: true
 generated: false
 summary: "Treat the private repository as a separate source component of the profile application and integrate it through explicit content and promotion contracts."
 tags:
@@ -16,14 +16,14 @@ tags:
 relations:
 - type: mitigates
   target: RISK-004-source-boundary-leakage
-  status: proposed
+  status: accepted
   rationale: "Explicit repository boundaries and promotion contracts reduce accidental private source disclosure."
-  reviewed: false
+  reviewed: true
 - type: addresses
   target: QS-005-publication-visibility-boundary
-  status: proposed
+  status: accepted
   rationale: "The private repository strategy supports source and publication visibility boundaries."
-  reviewed: false
+  reviewed: true
 metadata_version: '1.0'
 ---
 [[adr-009-private-repository-integration]]
@@ -31,11 +31,15 @@ metadata_version: '1.0'
 
 === Status
 
-Proposed.
+Accepted by the site owner.
 
 === Decision
 
-We propose to treat `profile-private` (`dieterbaier/profile-private`) as a separate source component of the same profile application, integrated through explicit content and promotion contracts instead of Git submodules or duplicated build logic.
+We treat `profile-private` (`dieterbaier/profile-private`) as a separate source component of the same profile application, integrated through explicit content and promotion contracts instead of Git submodules or duplicated build logic.
+
+The two repositories are checked out as siblings. The private build reaches the shared tooling through that sibling checkout and owns no copy of it. Private rendering and verification run locally; the private target needs no GitHub Actions deployment.
+
+Promotion moves an article from the private repository to the public one. It does not copy it: an article lives in exactly one source repository at a time, so there is never a second place to edit it and no question which one is true.
 
 The public repository remains the owner of shared build logic, validators, generators, theme assets, profile metadata contracts, and architecture documentation. The private repository owns private article, note, and protocol source content. Private content is rendered by reusing the public repository's build tooling through a documented checkout or local path contract.
 
@@ -88,8 +92,8 @@ PrivateBuild --> Generators : generate private target inputs
 PrivateBuild --> Theme : reuse presentation
 PrivateBuild --> PrivateDeployConfig : deploy protected target
 
-Promotion --> PrivateArticles : select cleaned article
-Promotion --> PublicArticles : copy as status=preview
+Promotion --> PrivateArticles : select and remove cleaned article
+Promotion --> PublicArticles : move in as status=preview
 
 PublicBuild --> PublicArticles : render public and preview targets
 PublicBuild --> Gradle
@@ -117,18 +121,31 @@ ArchitectureDocs ..> PrivateRepo : documents application-level decisions
 s| Sum s| +6 s| 0 s| +1 s| -2
 |===
 
-=== Proposed Integration Contract
+=== Integration Contract
 
 [cols="1,3", options="header"]
 |===
-| Contract | Proposed rule
+| Contract | Rule
 | Source ownership | Public source stays in `profile`; private source stays in `profile-private`.
 | Tooling ownership | Shared Gradle tasks, generators, validators, schemas, and theme assets are owned by `profile-dieterbaier`.
 | Private build input | The private repository provides content roots that match the public profile article metadata contract.
-| Tooling access | Private builds use a checked-out public repository path or a later packaged toolkit version; no submodule is required initially.
-| Promotion | A reviewed script copies selected article source and metadata from private to public source and sets `status: preview`.
+| Tooling access | The two repositories are checked out as siblings. The private build uses the public checkout's tooling directly; no submodule, no packaged version, no vendored copy.
+| No second implementation | The private repository holds no schema, validator, or generator of its own. Its build stops when it finds one.
+| Contract version | Every artifact declares `metadata_version`. The public validator declares which versions it accepts and rejects the rest, so content written against an older contract fails by name.
+| Promotion | A reviewed script validates an article against the public contract, then moves its source and sidecar metadata from private to public source and sets `status: preview`. Validation precedes the move, because a move that fails afterwards leaves the article in neither repository's intended state.
+| Private deployment | Private rendering and verification run locally. No GitHub Actions deployment for the private target.
 | Architecture documentation | Architecture decisions stay in the public repository unless private-only implementation creates a separate architectural concern.
 |===
+
+=== Preventing Contract Drift
+
+Two rules carry the drift concern, and they divide the failure between them.
+
+The **no second implementation** rule removes drift in the tooling rather than detecting it. A vendored copy keeps looking like the original after it has stopped being one, which is the property that made the divergence in `metamodel/artifact.schema.yaml` invisible; a repository that holds no copy cannot diverge in one.
+
+The **contract version** rule covers what remains: a sibling checkout that is simply older than the content beside it. `metadata_version` already exists in every artifact and in the schema, but nothing enforces its value, so the field carries no meaning today. Enforcing it makes a stale contract fail with a name attached, and makes raising the version the deliberate act it should be when the contract changes.
+
+Neither rule catches a contract change nobody versioned. That is a discipline gap rather than a mechanism gap, and no inexpensive check closes it.
 
 === Consequences
 
@@ -141,20 +158,23 @@ Positive:
 
 Negative:
 
-* The private repository build must locate compatible shared tooling.
-* Contract drift between repositories becomes possible and needs validation.
+* The private repository build must locate the sibling public checkout, and fails without it.
+* A sibling checkout can lag behind the content beside it. The contract version rule turns that into a named failure rather than a silent one.
 * Local development requires two checkouts for private builds.
+* A failed promotion is more expensive than under a copy, because the article has left its origin. Validation before the move is what keeps that cost theoretical.
 
 Neutral or follow-up:
 
 * A later packaging step may turn shared tooling into a reusable toolkit artifact if local path coupling becomes painful.
 * A Git submodule can be reconsidered if reproducible pinning becomes more important than simple authoring.
 
-=== Review Notes
+=== Review Outcome
 
-Before acceptance, confirm:
+The site owner confirmed the four open points at acceptance:
 
-* the private repository name is confirmed as `dieterbaier/profile-private`;
-* the initial tooling access mechanism, such as sibling checkout path versus packaged toolkit version;
-* whether private deployment runs locally, in GitHub Actions from the private repository, or both;
-* which compatibility check prevents private/public metadata contract drift.
+* the private repository is `dieterbaier/profile-private`;
+* tooling access is a sibling checkout, not a packaged version and not a submodule;
+* private deployment runs locally, not in GitHub Actions;
+* drift is prevented by the no-second-implementation rule together with an enforced `metadata_version`.
+
+The same review corrected promotion from a copy to a move.

--- a/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
@@ -158,7 +158,9 @@ The order follows from which failure is survivable. Removing from private first 
 | Commit and push private | Promotion is complete. | None.
 |===
 
-**The incomplete state is duplication, and it is detectable.** The same artifact `id` present in both repositories means a promotion stopped after the public push. That is the check a resumed promotion looks for, and it is why artifact IDs are stable and unique across the contract rather than per repository.
+**The incomplete state is duplication, and it is detectable.** The same artifact `id` present in both repositories is the signal a resumed promotion looks for, which is why artifact IDs are stable and unique across the contract rather than per repository.
+
+The signal is not conclusive on its own. A shared `id` can also mean a genuine collision — two different articles that ended up with the same identifier — and a resumption that trusted the `id` alone would overwrite public content with private content. Recognizing an interrupted promotion therefore means matching the public artifact against the private one being promoted, not matching identifiers. The three states a public `id` can represent, and their opposite responses, are specified in https://github.com/dieterbaier/profile/issues/85[GitHub issue #85].
 
 **A promoted article is never rolled back by moving it home.** If the article should not have been promoted, it is removed from the public repository like any other public content, and the public Git history keeps the record. Promotion is not reversible by re-running it backwards, because public history cannot be unpublished.
 

--- a/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
@@ -39,7 +39,9 @@ We treat `profile-private` (`dieterbaier/profile-private`) as a separate source 
 
 The two repositories are checked out as siblings. The private build reaches the shared tooling through that sibling checkout and owns no copy of it. Private rendering and verification run locally; the private target needs no GitHub Actions deployment.
 
-Promotion moves an article from the private repository to the public one. It does not copy it: an article lives in exactly one source repository at a time, so there is never a second place to edit it and no question which one is true.
+Promotion moves an article from the private repository to the public one rather than copying it, so that an article has exactly one authoritative source and no second place to edit it.
+
+Move is the outcome, not a property of the operation. Two repositories cannot be written atomically: the promotion is a saga with an ordering, states it can stop in, and a recovery step. The `Promotion Saga` section below defines them.
 
 The public repository remains the owner of shared build logic, validators, generators, theme assets, profile metadata contracts, and architecture documentation. The private repository owns private article, note, and protocol source content. Private content is rendered by reusing the public repository's build tooling through a documented checkout or local path contract.
 
@@ -92,8 +94,9 @@ PrivateBuild --> Generators : generate private target inputs
 PrivateBuild --> Theme : reuse presentation
 PrivateBuild --> PrivateDeployConfig : deploy protected target
 
-Promotion --> PrivateArticles : select and remove cleaned article
-Promotion --> PublicArticles : move in as status=preview
+Promotion --> PrivateArticles : 1. select and validate cleaned article
+Promotion --> PublicArticles : 2. write as status=preview (leading side)
+Promotion --> PrivateArticles : 3. remove the promoted article
 
 PublicBuild --> PublicArticles : render public and preview targets
 PublicBuild --> Gradle
@@ -132,10 +135,32 @@ s| Sum s| +6 s| 0 s| +1 s| -2
 | Tooling access | The two repositories are checked out as siblings. The private build uses the public checkout's tooling directly; no submodule, no packaged version, no vendored copy.
 | No second implementation | The private repository holds no schema, validator, or generator of its own. Its build stops when it finds one.
 | Contract version | Every artifact declares `metadata_version`. The public validator declares which versions it accepts and rejects the rest, so content written against an older contract fails by name.
-| Promotion | A reviewed script validates an article against the public contract, then moves its source and sidecar metadata from private to public source and sets `status: preview`. Validation precedes the move, because a move that fails afterwards leaves the article in neither repository's intended state.
+| Promotion | A reviewed script validates an article against the public contract, then transfers its source and sidecar metadata from private to public source and sets `status: preview`. Validation precedes any write, and the transfer follows the promotion saga below. Its outcome is a move; its execution is not atomic.
 | Private deployment | Private rendering and verification run locally. No GitHub Actions deployment for the private target.
 | Architecture documentation | Architecture decisions stay in the public repository unless private-only implementation creates a separate architectural concern.
 |===
+
+=== Promotion Saga
+
+Two Git repositories cannot be written in one transaction. Promotion therefore has a defined order, and every point it can stop at is a state someone has to be able to recognize and finish.
+
+**The public repository leads.** From the moment the promoted article lands there, it is the authoritative copy. Everything after that point is cleanup of the private side, never a source of truth.
+
+The order follows from which failure is survivable. Removing from private first would put the article nowhere if the public write then fails. Writing to public first can only ever produce a duplicate, and a duplicate is recoverable while a loss is not.
+
+[cols="1,2,2", options="header"]
+|===
+| Step | Stops here means | Recovery
+| Validate the article against the public contract | Nothing was written. The article is private and unchanged. | None needed. Fix the article and start over.
+| Write source and sidecar into public, `status: preview` | The public working tree holds an uncommitted addition. | Discard the working tree change and start over.
+| Commit and push public | The article is public and authoritative. The private copy still exists. | Continue with the private removal.
+| Remove the article from private | The private working tree holds an uncommitted deletion. | Discard or complete the deletion; either way the public copy stands.
+| Commit and push private | Promotion is complete. | None.
+|===
+
+**The incomplete state is duplication, and it is detectable.** The same artifact `id` present in both repositories means a promotion stopped after the public push. That is the check a resumed promotion looks for, and it is why artifact IDs are stable and unique across the contract rather than per repository.
+
+**A promoted article is never rolled back by moving it home.** If the article should not have been promoted, it is removed from the public repository like any other public content, and the public Git history keeps the record. Promotion is not reversible by re-running it backwards, because public history cannot be unpublished.
 
 === Preventing Contract Drift
 
@@ -143,9 +168,27 @@ Two rules carry the drift concern, and they divide the failure between them.
 
 The **no second implementation** rule removes drift in the tooling rather than detecting it. A vendored copy keeps looking like the original after it has stopped being one, which is the property that made the divergence in `metamodel/artifact.schema.yaml` invisible; a repository that holds no copy cannot diverge in one.
 
-The **contract version** rule covers what remains: a sibling checkout that is simply older than the content beside it. `metadata_version` already exists in every artifact and in the schema, but nothing enforces its value, so the field carries no meaning today. Enforcing it makes a stale contract fail with a name attached, and makes raising the version the deliberate act it should be when the contract changes.
+The **contract version** rule covers what remains: a sibling checkout that is simply older than the content beside it. Enforcing `metadata_version` will make a stale contract fail with a name attached, and will make raising the version the deliberate act it should be when the contract changes.
 
 Neither rule catches a contract change nobody versioned. That is a discipline gap rather than a mechanism gap, and no inexpensive check closes it.
+
+=== Implementation Status
+
+The decision holds; the rules it accepts are at different stages, and this section says which is which so the documentation does not claim protection that does not exist yet.
+
+[cols="2,1,2", options="header"]
+|===
+| Rule | State | Where
+| Sibling checkout as the tooling access mechanism | decided, not implemented | The private build, https://github.com/dieterbaier/profile/issues/86[#86]
+| No second implementation in the private repository | decided, not implemented | Checked by the private build, https://github.com/dieterbaier/profile/issues/86[#86], and by the promotion checks, https://github.com/dieterbaier/profile/issues/84[#84]
+| `metadata_version` accepted-version set enforced | decided, not implemented | https://github.com/dieterbaier/profile/issues/83[#83]
+| Promotion saga: validate, then public, then private | decided, not implemented | https://github.com/dieterbaier/profile/issues/84[#84] and https://github.com/dieterbaier/profile/issues/85[#85]
+| Private deployment runs locally | decided, not implemented | https://github.com/dieterbaier/profile/issues/87[#87]
+|===
+
+Today `metadata_version` is present in every artifact and in the schema, and the validator checks only that it is a string. Until https://github.com/dieterbaier/profile/issues/83[#83] closes, the field records an intention rather than enforcing one, and the drift protection rests on the no-second-implementation rule alone.
+
+**This is the gate on private-source work.** No slice that reads private source or promotes an article runs before the accepted-version check exists, because a promotion validated against an unenforced contract is the exact failure this decision claims to prevent.
 
 === Consequences
 
@@ -161,7 +204,8 @@ Negative:
 * The private repository build must locate the sibling public checkout, and fails without it.
 * A sibling checkout can lag behind the content beside it. The contract version rule turns that into a named failure rather than a silent one.
 * Local development requires two checkouts for private builds.
-* A failed promotion is more expensive than under a copy, because the article has left its origin. Validation before the move is what keeps that cost theoretical.
+* Promotion crosses a repository boundary and cannot be atomic. Its incomplete state is a duplicated article, which someone or something has to notice and finish. The saga puts that state on the recoverable side rather than removing it.
+* A promotion cannot be undone by reversing it. Once the public push has happened, the article is in public history, and withdrawing it is a public change rather than a return.
 
 Neutral or follow-up:
 
@@ -178,3 +222,5 @@ The site owner confirmed the four open points at acceptance:
 * drift is prevented by the no-second-implementation rule together with an enforced `metadata_version`.
 
 The same review corrected promotion from a copy to a move.
+
+A second review round sharpened two claims this record had overstated. A cross-repository move is not atomic, so the promotion is described as a saga with a leading repository, an order, its stop states, and their recovery. The `metadata_version` protection is decided but not yet built, so the `Implementation Status` section separates what holds from what runs.


### PR DESCRIPTION
Closes #80. Lifts the gate that held four slices of #26.

## What was decided

The site owner answered ADR-009's four review notes:

| Review note | Answer |
|---|---|
| Private repository name | `dieterbaier/profile-private` |
| Tooling access | Sibling checkouts. The private build uses the public checkout's tooling directly — no submodule, no packaged version, no vendored copy. |
| Where private deployment runs | Locally. No GitHub Actions deployment for the private target. |
| Contract drift check | No second implementation, plus an enforced `metadata_version`. |

The record now states these as rules in the integration contract rather than as notes appended to it, and `Review Notes` becomes `Review Outcome`.

## The drift check, and what it does not cover

Two rules, dividing the failure between them.

**No second implementation.** The private repository holds no schema, validator, or generator of its own; its build stops when it finds one. This removes drift in the tooling instead of detecting it. A vendored copy keeps looking like the original after it has stopped being one — the property that made the divergence in `metamodel/artifact.schema.yaml` invisible until someone opened the toolkit's file (#75).

**Contract version.** `metadata_version` already exists in every artifact and in the schema (`metamodel/profile-artifact.schema.yaml:152`), but the validator only checks that it is a string (`scripts/validate-profile-metamodel.rb:708`). Enforcing its value catches the one case the first rule leaves open: a sibling checkout older than the content beside it.

Neither catches a contract change nobody versioned. The ADR says so explicitly, because a gap that is not stated reads as a guarantee to a later reader.

## Promotion moves, it does not copy — as an outcome, not as an atomic operation

An article has exactly one **authoritative** source. A copy would leave two places to edit it and no answer to which is true.

Move is the goal, not a property of the operation. Two Git repositories cannot be written in one transaction, so the record describes a saga rather than claiming atomicity:

- **The public repository leads.** From its first write, the promoted article is the authoritative copy; everything after is cleanup of the private side.
- **Order: validate, write public, remove private.** It follows from which failure survives. Removing from private first would put the article nowhere if the public write then fails; writing to public first can only produce a duplicate, and a duplicate is recoverable while a loss is not.
- **The interim state is a deliberate duplicate**, and it is detectable: the same artifact `id` in both repositories means a promotion stopped after the public push. That is what a resumed run looks for.
- **Stop states and recovery** are a table in the ADR, one row per step.

The record also names what cannot be undone: after the public push, withdrawal is a public change rather than a return.

This changes more than a word. Under a copy, a failed promotion is harmless — the original stays private and the copy is discarded. Under a move, an article that fails validation after the public write has already been published, so validation runs before any write.

The consequence list changes with it: "Contract drift between repositories becomes possible and needs validation" is no longer true once there is one implementation, and is replaced by the two costs that are real — a sibling checkout that lags, and a failed promotion that is expensive because the article has moved.

## The ADR-008 edit

ADR-008 is accepted, and an accepted decision is not rewritten. Its promotion diagram said `copy source and sidecar metadata`, but its Decision section says *promoted* and never said copy. The edit corrects an error in the decision **basis**, not the decision, and the owner confirmed that reading. If a reviewer disagrees, the alternative is a superseding ADR rather than this diff.

## Verification

`validateArchitectureMetamodel`, `validateProfileMetamodel`, `generateArchitectureArtifacts`, and `buildArchitecture` are green. The tagged component block still resolves into the building block view, and the new prose renders into `build/architecture/index.html` with 20 diagrams referenced. The generated ADR index lists ADR-009 as `accepted`; generated files are gitignored, so the diff shows only the two sources.

## After merge

- #26 records the gate as lifted.
- The four slices behind it become sliceable: private target, promotion checks, promotion script, `private.dieterbaier.eu`.

