### PR TITLE
issue_83: Enforce the metadata contract version

### DIFF
--- a/ai-contracts/profile-artifact-metadata.md
+++ b/ai-contracts/profile-artifact-metadata.md
@@ -63,6 +63,34 @@ as project entries.
   own `<lang>/` subtree. There is no `mixed` value.
 - The original of a translation may be in any language. The default language is
   the fallback target, not the assumed source language.
+- Every artifact declares `metadata_version`, and it is one of the versions
+  `metamodel/profile-artifact.schema.yaml` accepts. An absent version is an
+  error, not the initial version: content that says nothing about its contract
+  would pass against a checkout too old to understand it.
+
+## Contract Version
+
+`metadata_version` says which version of this contract an artifact was written
+against. The accepted versions live in one place, the `metadata_version` enum in
+`metamodel/profile-artifact.schema.yaml`. The validator reads them from that file
+in its own checkout, so content validated through a checkout of this repository
+is judged by that checkout's contract rather than by whatever metamodel sits
+beside the content.
+
+New artifacts declare the current version. Copy it from the enum or from
+`templates/write-article/article.profile.yaml`; do not invent a value.
+
+Raise the version when a change to this contract would make older metadata
+wrong rather than merely incomplete — a field that changes meaning, a value that
+stops being accepted, a rule that reinterprets what is already written. Adding
+an optional field does not need a new version, because existing artifacts remain
+true under it.
+
+Raising it is a deliberate act with three parts, all in the same change: add the
+new version to the schema enum, migrate the artifacts that are being moved to
+it, and decide whether the previous version stays in the enum. Dropping a
+version from the enum is what makes unmigrated content fail by name, so drop it
+only when nothing that must still validate declares it.
 
 ## Validation
 

--- a/features/metadata-contract-version.feature
+++ b/features/metadata-contract-version.feature
@@ -1,0 +1,48 @@
+# Living documentation for the metadata contract version an artifact declares.
+#
+# Bridged to: test/profile_metadata_version_test.rb (classic Minitest, no native
+# BDD runner in this repository). Each scenario maps to a test method named after
+# the sanitized scenario title, with Given/When/Then comment anchors inside it.
+# Traceability is a reviewer-verifiable convention, not a build-enforced link.
+#
+# The rule comes from ADR-009. Promotion may run with the public repository's
+# validator applied to private content from a separate checkout, and nothing in
+# that arrangement notices when the checkout is older than the content beside it.
+# The declared version is what turns that into a named failure. It only works
+# while it is enforced, so the contract lives in the schema and the validator
+# reads it from there.
+
+Feature: Metadata contract version
+  As the owner of the profile publishing system
+  I want every artifact to declare a contract version the validator enforces
+  So that content and the checkout validating it cannot disagree in silence
+
+  Scenario: An artifact declaring an accepted contract version passes validation
+    Given an artifact declaring a contract version this checkout accepts
+    When the profile metadata is validated
+    Then validation reports no error about the contract version
+
+  Scenario: An artifact declaring an unsupported contract version is rejected by name
+    Given an artifact declaring a contract version this checkout does not accept
+    When the profile metadata is validated
+    Then validation fails naming the artifact, the declared version, and the accepted versions
+
+  Scenario: An artifact that declares no contract version fails validation
+    Given an artifact with no contract version at all
+    When the profile metadata is validated
+    Then validation fails naming the artifact and the missing field
+
+  Scenario: The accepted versions come from the metamodel schema
+    Given a metamodel schema listing the contract versions it accepts
+    When the accepted versions are read
+    Then they are the versions the schema lists
+
+  Scenario: A schema that names no accepted versions stops the validator
+    Given a metamodel schema whose contract version field lists no versions
+    When the accepted versions are read
+    Then reading fails naming the schema instead of assuming a version
+
+  Scenario: Content is judged by the contract of the checkout validating it
+    Given content whose own metamodel accepts a version this checkout does not
+    When the profile metadata is validated
+    Then the declared version is rejected against this checkout's accepted versions

--- a/metamodel/profile-artifact.schema.yaml
+++ b/metamodel/profile-artifact.schema.yaml
@@ -11,6 +11,7 @@ required:
   - status
   - owner
   - created
+  - metadata_version
 properties:
   id:
     type: string
@@ -151,7 +152,16 @@ properties:
       $ref: "relations.schema.yaml#/$defs/relation"
   metadata_version:
     type: string
-    default: "1.0"
+    description: >-
+      The version of this metadata contract the artifact was written against.
+      The enum is the single declaration of which versions are accepted: the
+      validator reads it from this file rather than carrying its own list, so a
+      build using a checkout of this repository as its metamodel can report what
+      that checkout accepts without running Ruby. Raising it is a deliberate act
+      described in ai-contracts/profile-artifact-metadata.md; a value outside
+      the enum, and an absent value, both fail validation.
+    enum:
+      - "1.0"
 allOf:
   # Article-series navigation is only meaningful for articles.
   - if:

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -12,7 +12,7 @@ require 'set'
 require 'yaml'
 
 class ProfileArtifactValidator
-  REQUIRED = %w[id type title status owner created].freeze
+  REQUIRED = %w[id type title status owner created metadata_version].freeze
   PROPERTIES = %w[id type title status owner created updated published reviewed generated language translation_of translation_source_digest translation_divergence audience channels summary summary_de summary_en source tags skills previous next relations metadata_version].freeze
   TYPES = %w[ProfilePage Article ShortThought CV Project ProfessionalExperience Education Skill Contact ProfileFragment].freeze
   STATUSES = %w[draft proposed preview reviewed published private archived deprecated].freeze
@@ -56,9 +56,50 @@ class ProfileArtifactValidator
   ARTIFACT_ID_PATTERN = /\A[A-Z]+-[0-9]{3,}(-[a-z0-9]+)*\z/
   TAG_PATTERN = /\A[A-Za-z0-9][A-Za-z0-9-]*\z/
 
+  # Where the accepted metadata contract versions are declared.
+  #
+  # ADR-009 rests its contract-drift protection on an enforced version, and that
+  # rule only holds while there is exactly one declaration of the accepted set.
+  # It lives in the schema, next to the field it governs, and is read from there
+  # rather than restated here. A build that borrows this repository as its
+  # metamodel — the sibling-checkout arrangement ADR-009 accepts — reads the same
+  # file to find out what that checkout accepts, without running this script.
+  #
+  # Resolved from this script's own directory and not from `--root`: the set
+  # describes the validator, not the content under validation. Pointed at another
+  # checkout's content, this one still answers with its own contract, which is
+  # the whole point of enforcing the version.
+  SCHEMA_PATH = Pathname.new(__dir__).join('..', 'metamodel', 'profile-artifact.schema.yaml').expand_path
+
   # Raised when the publication selection cannot name the source of an article
   # it has to exclude. It is deliberately fatal: see excluded_article_sources.
   class UnresolvableArticleSource < StandardError; end
+
+  # Raised when the schema cannot say which contract versions are accepted.
+  # Fatal by construction: a validator that cannot state its own contract cannot
+  # enforce it, and falling back to a built-in default here would restore the
+  # silent mismatch the field exists to prevent.
+  class UnreadableMetadataContract < StandardError; end
+
+  # Reads the accepted contract versions from the schema. A class method because
+  # the answer belongs to the checkout rather than to a validation run, and
+  # because a private build may want it without scanning any content.
+  def self.supported_metadata_versions(schema_path = SCHEMA_PATH)
+    schema_path = Pathname.new(schema_path)
+    raise UnreadableMetadataContract, "metamodel schema not found: #{schema_path}" unless schema_path.file?
+
+    schema = YAML.safe_load(schema_path.read, aliases: false)
+    versions = schema.is_a?(Hash) ? schema.dig('properties', 'metadata_version', 'enum') : nil
+    unless versions.is_a?(Array) && !versions.empty? && versions.all? { |version| version.is_a?(String) }
+      raise UnreadableMetadataContract,
+            "#{schema_path} declares no metadata_version enum of strings; " \
+            'the accepted contract versions are undefined'
+    end
+
+    versions.map(&:freeze).freeze
+  rescue Psych::SyntaxError => e
+    raise UnreadableMetadataContract, "#{schema_path} is not valid YAML: #{e.message.lines.first.strip}"
+  end
 
   Artifact = Struct.new(:path, :metadata, keyword_init: true)
   attr_reader :errors, :warnings, :root, :profile_dir
@@ -751,7 +792,8 @@ class ProfileArtifactValidator
       validate_string(artifact, 'summary_de', required: false)
       validate_string(artifact, 'summary_en', required: false)
       validate_string(artifact, 'source', required: false)
-      validate_string(artifact, 'metadata_version', required: false)
+      validate_string(artifact, 'metadata_version')
+      validate_metadata_version(artifact)
       validate_enum(artifact, 'type', TYPES)
       validate_enum(artifact, 'status', STATUSES)
       validate_enum(artifact, 'language', LANGUAGES, required: false)
@@ -779,6 +821,28 @@ class ProfileArtifactValidator
 
       validate_article_source_resolvable(artifact)
     end
+  end
+
+  # An artifact says which version of this metadata contract it was written
+  # against, and the validator accepts only versions it knows. `metadata_version`
+  # is in REQUIRED, so an absent value is already reported as a missing field:
+  # absence is not read as the initial version. A default here would let content
+  # say nothing about its contract and still pass, and a checkout older than the
+  # content beside it would then accept it silently — the mismatch ADR-009 names
+  # and the reason the field exists.
+  def validate_metadata_version(artifact)
+    value = artifact.metadata['metadata_version']
+    # Absent, empty, or not a string: already reported by REQUIRED and
+    # validate_string. Only the value is this check's business.
+    return unless value.is_a?(String) && !value.empty?
+    return if supported_metadata_versions.include?(value)
+
+    errors << "#{relative(artifact.path)} declares metadata_version '#{value}', " \
+              "which this checkout does not accept (accepted: #{supported_metadata_versions.join(', ')})"
+  end
+
+  def supported_metadata_versions
+    @supported_metadata_versions ||= self.class.supported_metadata_versions
   end
 
   # A sidecar says which file it describes. This is not what keeps the

--- a/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
@@ -170,7 +170,11 @@ Two rules carry the drift concern, and they divide the failure between them.
 
 The **no second implementation** rule removes drift in the tooling rather than detecting it. A vendored copy keeps looking like the original after it has stopped being one, which is the property that made the divergence in `metamodel/artifact.schema.yaml` invisible; a repository that holds no copy cannot diverge in one.
 
-The **contract version** rule covers what remains: a sibling checkout that is simply older than the content beside it. Enforcing `metadata_version` will make a stale contract fail with a name attached, and will make raising the version the deliberate act it should be when the contract changes.
+The **contract version** rule covers what remains: a sibling checkout that is simply older than the content beside it. Enforcing `metadata_version` makes a stale contract fail with a name attached, and makes raising the version the deliberate act it should be when the contract changes.
+
+The rule needs one place where the accepted versions are declared, and it is the `metadata_version` enum in `metamodel/profile-artifact.schema.yaml`. The validator reads it from there rather than carrying a second list, and reads it from its own checkout rather than from the tree it was pointed at, so a run against private content answers with the contract of the tooling doing the validating. A build that borrows this repository as its metamodel can read the same file to report what its checkout accepts.
+
+Absence is not read as the initial version. An artifact that declares no `metadata_version` fails as a missing field, because a default would let content say nothing about its contract and still pass — and a checkout older than that content would then accept it silently, which is the mismatch this rule exists to catch.
 
 Neither rule catches a contract change nobody versioned. That is a discipline gap rather than a mechanism gap, and no inexpensive check closes it.
 
@@ -183,14 +187,14 @@ The decision holds; the rules it accepts are at different stages, and this secti
 | Rule | State | Where
 | Sibling checkout as the tooling access mechanism | decided, not implemented | The private build, https://github.com/dieterbaier/profile/issues/86[#86]
 | No second implementation in the private repository | decided, not implemented | Checked by the private build, https://github.com/dieterbaier/profile/issues/86[#86], and by the promotion checks, https://github.com/dieterbaier/profile/issues/84[#84]
-| `metadata_version` accepted-version set enforced | decided, not implemented | https://github.com/dieterbaier/profile/issues/83[#83]
+| `metadata_version` accepted-version set enforced | implemented | Declared in `metamodel/profile-artifact.schema.yaml`, enforced by `scripts/validate-profile-metamodel.rb`, https://github.com/dieterbaier/profile/issues/83[#83]
 | Promotion saga: validate, then public, then private | decided, not implemented | https://github.com/dieterbaier/profile/issues/84[#84] and https://github.com/dieterbaier/profile/issues/85[#85]
 | Private deployment runs locally | decided, not implemented | https://github.com/dieterbaier/profile/issues/87[#87]
 |===
 
-Today `metadata_version` is present in every artifact and in the schema, and the validator checks only that it is a string. Until https://github.com/dieterbaier/profile/issues/83[#83] closes, the field records an intention rather than enforcing one, and the drift protection rests on the no-second-implementation rule alone.
+`metadata_version` is required on every artifact, and the validator rejects a version outside the accepted set by name. Both drift rules are therefore in force for content, and what remains unbuilt is the private build that would use them.
 
-**This is the gate on private-source work.** No slice that reads private source or promotes an article runs before the accepted-version check exists, because a promotion validated against an unenforced contract is the exact failure this decision claims to prevent.
+**This was the gate on private-source work.** No slice that reads private source or promotes an article was to run before the accepted-version check existed, because a promotion validated against an unenforced contract is the exact failure this decision claims to prevent. https://github.com/dieterbaier/profile/issues/83[#83] closed that gate; the remaining private slices are ordered by their own dependencies.
 
 === Consequences
 

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -27,6 +27,29 @@ Deployment credentials are scoped by target system. `PROFILE_REPO_TOKEN` grants 
 
 Metadata validation runs before documentation rendering. The architecture validator follows the architecture-knowledge-toolkit metamodel. The profile validator checks profile artifact metadata, relations, and generated indexes.
 
+== Metadata Contract Version
+
+Every profile artifact declares the version of the metadata contract it was
+written against, and the validator accepts only versions it knows. The accepted
+versions are declared once, as the `metadata_version` enum in
+`metamodel/profile-artifact.schema.yaml`; the validator reads them from there
+instead of holding a second list, and any build can read the same file without
+running the validator.
+
+The set is read from the validator's own checkout rather than from the tree it
+was pointed at. Content validated from elsewhere — the private repository
+reaching the shared tooling through a sibling checkout, as ADR-009 accepts — is
+judged by the contract of the tooling doing the validating, which is what makes
+a checkout older than the content beside it fail by name instead of passing.
+
+An artifact that declares no version fails as a missing field. Treating absence
+as the initial version would let content say nothing about its contract and
+still pass, and the silent case is the one this field exists to remove.
+
+The observable behaviour is specified in
+`features/metadata-contract-version.feature` and bridged to
+`test/profile_metadata_version_test.rb`.
+
 == Publication Selection
 
 A publication target renders the article statuses that target allows, decided in

--- a/test/profile_comments_test.rb
+++ b/test/profile_comments_test.rb
@@ -21,6 +21,7 @@ class ProfileCommentsTest < Minitest::Test
         'status' => 'published',
         'owner' => 'Test Owner',
         'created' => '2026-01-01',
+        'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first,
         'source' => 'articles/example.adoc'
       }.to_yaml)
       validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
@@ -142,6 +143,7 @@ class ProfileCommentsTest < Minitest::Test
           'status' => status,
           'owner' => 'Test Owner',
           'created' => '2026-01-01',
+          'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first,
           'channels' => channels,
           'source' => "articles/#{slug}.adoc"
         }.to_yaml)

--- a/test/profile_language_alternates_test.rb
+++ b/test/profile_language_alternates_test.rb
@@ -32,7 +32,7 @@ class ProfileLanguageAlternatesTest < Minitest::Test
         metadata = {
           'id' => page.fetch(:id), 'type' => 'ProfilePage', 'title' => slug, 'status' => 'published',
           'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => page.fetch(:language),
-          'source' => source
+          'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first, 'source' => source
         }
         metadata['translation_of'] = page[:translation_of] if page[:translation_of]
         (root + "#{rel_dir}/#{slug}.profile.yaml").write(metadata.to_yaml)
@@ -97,7 +97,8 @@ class ProfileLanguageAlternatesTest < Minitest::Test
         (root + source).write("= entry\n")
         (root + "#{rel_dir}/entry.profile.yaml").write({
           'id' => id, 'type' => 'Article', 'title' => id, 'status' => 'published', 'owner' => 'Test Owner',
-          'created' => '2026-01-01', 'language' => language, 'source' => source
+          'created' => '2026-01-01', 'language' => language, 'source' => source,
+          'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first
         }.to_yaml)
       end
 

--- a/test/profile_language_test.rb
+++ b/test/profile_language_test.rb
@@ -88,6 +88,7 @@ class ProfileLanguageTest < Minitest::Test
       'status' => artifact.fetch(:status, 'published'),
       'owner' => 'Test Owner',
       'created' => '2026-01-01',
+      'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first,
       'source' => source_rel
     }
     %i[language translation_of translation_source_digest translation_divergence tags channels].each do |field|

--- a/test/profile_listings_test.rb
+++ b/test/profile_listings_test.rb
@@ -55,6 +55,7 @@ class ProfileListingsTest < Minitest::Test
       'status' => article.fetch(:status, 'published'),
       'owner' => 'Test Owner',
       'created' => article.fetch(:created, '2026-01-01'),
+      'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first,
       'source' => source_rel
     }
     %i[published summary summary_de summary_en].each do |key|
@@ -344,7 +345,7 @@ class ProfileListingsTest < Minitest::Test
         metadata = {
           'id' => article.fetch(:id), 'type' => 'Article', 'title' => slug, 'status' => 'published',
           'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => article.fetch(:language),
-          'source' => source, 'tags' => article.fetch(:tags, [])
+          'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first, 'source' => source, 'tags' => article.fetch(:tags, [])
         }
         (root + "#{rel_dir}/#{slug}.profile.yaml").write(metadata.to_yaml)
       end

--- a/test/profile_metadata_version_test.rb
+++ b/test/profile_metadata_version_test.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for the metadata contract version.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in
+# features/metadata-contract-version.feature, with Given/When/Then comment
+# anchors separating Arrange, Act, and Assert. Each test builds an isolated
+# temporary profile tree so the real repository is never touched.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+
+require_relative '../scripts/validate-profile-metamodel'
+
+class ProfileMetadataVersionTest < Minitest::Test
+  # A version this checkout accepts, taken from the schema rather than restated,
+  # so raising the contract does not silently strand these tests on an old value.
+  def accepted_version
+    ProfileArtifactValidator.supported_metadata_versions.first
+  end
+
+  def with_artifact(spec)
+    Dir.mktmpdir('profile-metadata-version-test') do |dir|
+      root = Pathname.new(dir)
+      (root + 'articles').mkpath
+      (root + 'articles/sample.adoc').write("= Sample\n")
+      (root + 'articles/sample.profile.yaml').write(metadata_yaml(spec))
+
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      artifacts = validator.validate
+      yield(validator, artifacts, root)
+    end
+  end
+
+  def metadata_yaml(spec)
+    metadata = {
+      'id' => 'ART-901-sample',
+      'type' => 'Article',
+      'title' => 'Sample',
+      'status' => 'draft',
+      'owner' => 'Test Owner',
+      'created' => '2026-01-01',
+      'source' => 'articles/sample.adoc'
+    }
+    metadata['metadata_version'] = spec[:metadata_version] unless spec[:omit_metadata_version]
+    metadata.to_yaml
+  end
+
+  # Writes a schema whose metadata_version field lists the given versions. `nil`
+  # writes the field without an enum, which is a schema that cannot answer.
+  def write_schema(path, versions)
+    field = versions.nil? ? { 'type' => 'string' } : { 'type' => 'string', 'enum' => versions }
+    path.dirname.mkpath
+    path.write({ 'type' => 'object', 'properties' => { 'metadata_version' => field } }.to_yaml)
+    path
+  end
+
+  def contract_errors(validator)
+    validator.errors.grep(/metadata_version/)
+  end
+
+  def test_an_artifact_declaring_an_accepted_contract_version_passes_validation
+    # Given: an artifact declaring a contract version this checkout accepts
+    with_artifact(metadata_version: accepted_version) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated (in with_artifact)
+      # Then: validation reports no error about the contract version
+      assert_empty contract_errors(validator)
+    end
+  end
+
+  def test_an_artifact_declaring_an_unsupported_contract_version_is_rejected_by_name
+    # Given: an artifact declaring a contract version this checkout does not accept
+    unsupported = '0.9'
+    refute_includes ProfileArtifactValidator.supported_metadata_versions, unsupported
+
+    with_artifact(metadata_version: unsupported) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated (in with_artifact)
+      # Then: validation fails naming the artifact, the declared version, and the
+      # accepted versions
+      errors = contract_errors(validator)
+      assert_equal 1, errors.length
+      error = errors.first
+      assert_includes error, 'articles/sample.profile.yaml'
+      assert_includes error, "'#{unsupported}'"
+      ProfileArtifactValidator.supported_metadata_versions.each do |version|
+        assert_includes error, version
+      end
+    end
+  end
+
+  def test_an_artifact_that_declares_no_contract_version_fails_validation
+    # Given: an artifact with no contract version at all
+    with_artifact(omit_metadata_version: true) do |validator, _artifacts, _root|
+      # When: the profile metadata is validated (in with_artifact)
+      # Then: validation fails naming the artifact and the missing field
+      errors = contract_errors(validator)
+      refute_empty errors
+      assert(errors.any? { |error| error.include?('articles/sample.profile.yaml') && error.include?('missing required field') })
+    end
+  end
+
+  def test_the_accepted_versions_come_from_the_metamodel_schema
+    # Given: a metamodel schema listing the contract versions it accepts
+    Dir.mktmpdir('profile-metadata-schema-test') do |dir|
+      schema = write_schema(Pathname.new(dir) + 'profile-artifact.schema.yaml', %w[1.0 2.0])
+
+      # When: the accepted versions are read
+      versions = ProfileArtifactValidator.supported_metadata_versions(schema)
+
+      # Then: they are the versions the schema lists
+      assert_equal %w[1.0 2.0], versions
+    end
+  end
+
+  def test_a_schema_that_names_no_accepted_versions_stops_the_validator
+    # Given: a metamodel schema whose contract version field lists no versions
+    Dir.mktmpdir('profile-metadata-schema-test') do |dir|
+      schema = write_schema(Pathname.new(dir) + 'profile-artifact.schema.yaml', nil)
+
+      # When: the accepted versions are read
+      error = assert_raises(ProfileArtifactValidator::UnreadableMetadataContract) do
+        ProfileArtifactValidator.supported_metadata_versions(schema)
+      end
+
+      # Then: reading fails naming the schema instead of assuming a version
+      assert_includes error.message, schema.to_s
+      assert_includes error.message, 'metadata_version'
+    end
+  end
+
+  def test_content_is_judged_by_the_contract_of_the_checkout_validating_it
+    # Given: content whose own metamodel accepts a version this checkout does not
+    unsupported = '0.9'
+    refute_includes ProfileArtifactValidator.supported_metadata_versions, unsupported
+
+    with_artifact(metadata_version: unsupported) do |validator, _artifacts, root|
+      write_schema(root + 'metamodel/profile-artifact.schema.yaml', [unsupported])
+
+      # When: the profile metadata is validated
+      validator = ProfileArtifactValidator.new(root: root, profile_dir: root)
+      validator.validate
+
+      # Then: the declared version is rejected against this checkout's accepted
+      # versions, not against the metamodel sitting beside the content
+      errors = contract_errors(validator)
+      assert_equal 1, errors.length
+      assert_includes errors.first, ProfileArtifactValidator.supported_metadata_versions.join(', ')
+    end
+  end
+end

--- a/test/profile_navigation_test.rb
+++ b/test/profile_navigation_test.rb
@@ -45,6 +45,7 @@ class ProfileNavigationTest < Minitest::Test
       'status' => article.fetch(:status, 'published'),
       'owner' => 'Test Owner',
       'created' => article.fetch(:created, '2026-01-01'),
+      'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first,
       'source' => source_rel
     }
     metadata['tags'] = article[:tags] if article.key?(:tags)

--- a/test/profile_publication_status_test.rb
+++ b/test/profile_publication_status_test.rb
@@ -54,7 +54,8 @@ class ProfilePublicationStatusTest < Minitest::Test
       'title' => spec.fetch(:title, spec.fetch(:slug)),
       'status' => spec.fetch(:status, 'published'),
       'owner' => 'Test Owner',
-      'created' => spec.fetch(:created, '2026-01-01')
+      'created' => spec.fetch(:created, '2026-01-01'),
+      'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first
     }
     metadata['source'] = spec.fetch(:source, source_rel) unless spec[:omit_source]
     %i[language translation_of previous next tags].each do |key|

--- a/test/profile_translation_test.rb
+++ b/test/profile_translation_test.rb
@@ -51,7 +51,8 @@ class ProfileTranslationTest < Minitest::Test
   def metadata(id, language, source, extra = {})
     {
       'id' => id, 'type' => 'Article', 'title' => id, 'status' => 'published',
-      'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => language, 'source' => source
+      'owner' => 'Test Owner', 'created' => '2026-01-01', 'language' => language, 'source' => source,
+      'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first
     }.merge(extra).to_yaml
   end
 


### PR DESCRIPTION
Closes https://github.com/dieterbaier/profile/issues/83

ADR-009 rests its contract-drift protection on an enforced `metadata_version`, and the validator checked only that the field was a string. The field recorded an intention nobody verified, which is why #83 is the gate the private-source slices wait behind.

## The three decisions the issue left open

**Where the accepted set lives.** In the schema, as the `enum` on the field it governs. The validator reads it from there instead of carrying a second list, so the two cannot hold different answers, and any build can read the accepted versions from a YAML file without running Ruby — which is what the issue asks for when it says the set must be readable from outside the validator.

**Which checkout's contract wins.** The schema is resolved from the script's own directory, not from `--root`. The set describes the validator rather than the content under validation: pointed at private content in a sibling checkout, this validator still answers with its own contract. Resolving from `--root` would have made it read the metamodel sitting next to the content it is judging, which is not a check at all. `test_content_is_judged_by_the_contract_of_the_checkout_validating_it` pins this.

**An absent value.** An error, not the initial version. `metadata_version` joined `REQUIRED`. A default would let content say nothing about its contract and still pass, and a checkout too old to understand that content would then accept it silently — the mismatch the field exists to remove. All 38 artifacts already declare it, so the real tree validates unchanged.

## What that costs elsewhere

Seven test files are in the diff for one reason: their fixtures built metadata without the field, so they modelled artifacts that would no longer validate. They now take the version from the schema rather than hardcoding `1.0`, so raising the contract does not strand them.

## Specification

`features/metadata-contract-version.feature`, six scenarios, bridged to `test/profile_metadata_version_test.rb` by the sanitized-scenario-title convention.

## Architecture impact

ADR-009's Implementation Status listed this rule as decided but not implemented and named it the gate on private-source work. Both statements are now out of date, so the table moves to `implemented` and the gate paragraph is rewritten in the past tense. The decision itself is unchanged. Crosscutting concepts gain the rule as a concept, and `ai-contracts/profile-artifact-metadata.md` says when the version is raised — including that dropping the old value from the enum is the part that does the work.

## Verification

```
ruby scripts/validate-profile-metamodel.rb          # 38 artifacts, 0 errors
./gradlew validateProfileMetamodel validateArchitectureMetamodel
ruby -Itest test/profile_metadata_version_test.rb   # and the nine other Minitest files
```

- Profile validation: 38 artifacts, 0 errors, 1 pre-existing warning (88 of 95 fragments untranslated).
- Architecture validation: 56 artifacts, 0 errors.
- Minitest: 121 runs, 461 assertions, 0 failures. Node: 7 passed.

Not verified: no build of the private target exists yet, so the sibling-checkout case is covered by the scenario above and by nothing running against a real second repository.

## Noted, not done

`scripts/validate-metamodel.rb` does not check `metadata_version` at all, though every architecture artifact declares it. That is toolkit-owned and the lifecycle this field serves is profile content, not architecture documentation, so it stays outside this pull request and goes upstream instead.