### PR TITLE
issue_86: Render the private content root locally

### DIFF
--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -156,6 +156,9 @@ jobs:
             testProfileNavigation \
             testProfileListings \
             testProfileComments \
+            testProfileMetadataVersion \
+            testProfilePrivateTarget \
+            testPrivateCheckoutContract \
             testSiteMetadata
 
   deploy-site:

--- a/.github/workflows/update-profile.yml
+++ b/.github/workflows/update-profile.yml
@@ -152,14 +152,7 @@ jobs:
             generateArchitectureArtifacts \
             generateArticleSummaries \
             checkAgentAdapters \
-            testAgentAdapters \
-            testProfileNavigation \
-            testProfileListings \
-            testProfileComments \
-            testProfileMetadataVersion \
-            testProfilePrivateTarget \
-            testPrivateCheckoutContract \
-            testSiteMetadata
+            testAll
 
   deploy-site:
     needs: [build-docs, detect-changes]

--- a/README.md
+++ b/README.md
@@ -68,6 +68,45 @@ Additional steps:
 
 ---
 
+## 🔒 Private-to-public article lifecycle
+
+An article should be able to be written, reviewed, and published without
+becoming public merely by existing in a repository. Drafts therefore live in a
+second, private repository —
+[`dieterbaier/profile-private`](https://github.com/dieterbaier/profile-private),
+which is not publicly reachable — and move here when they are ready to be seen.
+
+```
+profile-private            profile (this repository)
+  drafts, notes    ──────▶   preview  ──────▶  published
+  status: private            status: preview   status: published
+```
+
+* **This repository owns the tooling.** Build, validators, generators, schemas,
+  and theme live here. The private repository holds content only and reaches
+  them through a sibling checkout; its build stops if it ever grows a copy of
+  its own.
+* **Targets are selected by metadata, not by location.** The public site renders
+  `status: published` and nothing else, and fails rather than skips when it
+  cannot name a source it must exclude.
+* **Promotion is a move, not a copy**, so an article has one authoritative
+  source. Because two repositories cannot be written in one transaction, it is a
+  saga with a leading side and a defined recovery for every point it can stop at.
+
+The decisions are ADR-008 (the lifecycle), ADR-009 (private repository
+integration), ADR-011 (preview visibility without authentication), and ADR-012
+(what the private target renders), all in
+[the architecture documentation](https://architecture.dieterbaier.eu). Most of
+the workflow is decided and documented; what is built is recorded per rule in
+each record's implementation status, rather than implied by the diagram above.
+
+To render the private drafts locally, check the two repositories out as siblings
+and run `./gradlew buildSitePrivate` (or `./build.sh buildSitePrivate`) here. The
+target lands in `build/site-private`, carries `noindex` on every page, and is
+deployed by nothing.
+
+---
+
 ## 🚀 Usage
 
 Available tasks:

--- a/build.gradle
+++ b/build.gradle
@@ -531,6 +531,9 @@ tasks.register('testProfileComments') {
     description = 'Runs the GitHub-backed article comments behaviour tests.'
     group = 'verification'
     inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_comments_test.rb')
+    // The task runs this file too; leaving it undeclared meant a change to it
+    // did not make the task out of date.
+    inputs.files('test/article_comments_test.mjs')
     inputs.files('features/article-comments.feature', 'src-content/theme/article-comments.js', 'src-content/theme/style.css')
     inputs.files('templates/write-article/article.adoc')
 
@@ -814,8 +817,22 @@ def requirePrivateCheckout = { ->
 }
 
 // Asked of the private tree the same way the public one is asked, and only when
-// there is a tree to ask about. Without a sibling the list is empty and the
-// render task never runs, because requirePrivateCheckout stops it first.
+// there is a tree to ask about.
+//
+// This runs while the build configures itself, and it has to: the Asciidoctor
+// plugin resolves a task's source tree when it determines that task's
+// dependencies, so there is no later point at which an exclusion still applies.
+//
+// What it must not do is fail there. A private checkout that exists but cannot
+// be read is not the same as no checkout at all, and an exception here would
+// break `./gradlew tasks`, `validateArchitectureMetamodel`, and every other
+// invocation that has nothing to do with private content. The first version of
+// this block did exactly that.
+//
+// So the failure is carried instead of thrown, and the target fails closed:
+// without a trustworthy list it renders nothing, and the tasks that need the
+// list report why when they run.
+def privateSelectionFailure = null
 def privateArticleExclusions = {
     if (!privateSiteDir.isDirectory()) {
         return [] as Set
@@ -831,12 +848,11 @@ def privateArticleExclusions = {
                    '--includes-dir', publicIncludesDir.absolutePath].execute(null, rootDir)
     process.waitForProcessOutput(stdout, stderr)
 
-    // Fail closed, as the public selection does: without a trustworthy list the
-    // safe answer is to render nothing.
     if (process.exitValue() != 0) {
-        throw new GradleException(
+        privateSelectionFailure =
                 'Could not determine which articles the private target may render.\n' +
-                        "ruby scripts/validate-profile-metamodel.rb --target private failed:\n${stderr}")
+                "ruby scripts/validate-profile-metamodel.rb --target private failed:\n${stderr}"
+        return null
     }
 
     stdout.toString().readLines().findAll { !it.trim().isEmpty() }.toSet()
@@ -888,19 +904,29 @@ tasks.named('buildSitePrivate') {
     // finished page. Anything outside that set is absent from the target rather
     // than merely unlinked.
     sources {
-        def prefix = "${privateSiteDir.absolutePath}/"
-        privateArticleExclusions.each { exclusion ->
-            // The list is relative to the private root; a source spec matches
-            // relative to its own source directory.
-            def absolute = new File(privateCheckoutDir, exclusion).absolutePath
-            if (absolute.startsWith(prefix)) {
-                exclude absolute.substring(prefix.length())
+        if (privateSelectionFailure != null) {
+            // No trustworthy list, so nothing is rendered. The task still fails
+            // below with the reason; this is what holds if that guard is ever
+            // removed.
+            exclude '**/*'
+        } else {
+            def prefix = "${privateSiteDir.absolutePath}/"
+            privateArticleExclusions.each { exclusion ->
+                // The list is relative to the private root; a source spec matches
+                // relative to its own source directory.
+                def absolute = new File(privateCheckoutDir, exclusion).absolutePath
+                if (absolute.startsWith(prefix)) {
+                    exclude absolute.substring(prefix.length())
+                }
             }
         }
     }
 
     doFirst {
         requirePrivateCheckout()
+        if (privateSelectionFailure != null) {
+            throw new GradleException(privateSelectionFailure)
+        }
     }
 
     // No canonical link and a robots tag on every page. The target is read
@@ -926,6 +952,9 @@ tasks.register('verifyPrivateTargetHasOnlyAllowedArticles') {
 
     doLast {
         requirePrivateCheckout()
+        if (privateSelectionFailure != null) {
+            throw new GradleException(privateSelectionFailure)
+        }
         exec {
             commandLine 'ruby', 'scripts/validate-profile-metamodel.rb',
                     '--verify-public-target-output',
@@ -934,6 +963,19 @@ tasks.register('verifyPrivateTargetHasOnlyAllowedArticles') {
                     '--profile-dir', privateContentDir.absolutePath,
                     '--includes-dir', publicIncludesDir.absolutePath,
                     '--output-root', rootDir.absolutePath
+        }
+    }
+}
+
+tasks.register('testProfilePublicationStatus') {
+    description = 'Runs the publication status selection behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'test/profile_publication_status_test.rb',
+                 'features/article-publication-status.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_publication_status_test.rb'
         }
     }
 }
@@ -1043,4 +1085,49 @@ tasks.register('buildAll') {
     dependsOn tasks.named('buildCVPersonal')
     dependsOn tasks.named('buildReadme')
     dependsOn tasks.named('buildArchitecture')
+}
+
+// Every behaviour test task, collected rather than listed.
+//
+// The list of test tasks was previously written out again in the CI workflow,
+// and it drifted: four registered tasks were never run there, and two test
+// files had no task at all. A test nothing runs is not a check, and the drift
+// is invisible because the pipeline stays green either way.
+//
+// Matching by name keeps a new test task from having to be remembered twice.
+tasks.register('testAll') {
+    description = 'Runs every behaviour test task.'
+    group = 'verification'
+    dependsOn tasks.matching { it.name.startsWith('test') && it.name != 'testAll' }
+    dependsOn tasks.named('verifyEveryTestFileHasATask')
+}
+
+// The other half of the same drift: a test file that no task names is invisible
+// whether or not the pipeline runs an aggregate. This asserts the contract
+// itself rather than trusting it, the way the public render tasks are asserted
+// to reach metadata validation.
+tasks.register('verifyEveryTestFileHasATask') {
+    description = 'Fails when a file under test/ is not an input of any test task.'
+    group = 'verification'
+
+    doLast {
+        def declared = tasks.matching { it.name.startsWith('test') && it.name != 'testAll' }
+                .collect { it.inputs.files.files }
+                .flatten()
+                .collect { it.absolutePath }
+                .toSet()
+
+        def orphans = fileTree('test').matching { include '**/*_test.rb'; include '**/*test*.mjs' }
+                .files
+                .findAll { !declared.contains(it.absolutePath) }
+                .collect { it.name }
+                .sort()
+
+        if (!orphans.isEmpty()) {
+            throw new GradleException(
+                    "No test task names these test file(s), so nothing runs them:\n" +
+                    orphans.collect { "  - test/${it}" }.join('\n') + "\n" +
+                    "  Register a task for each and let testAll pick it up.")
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -756,6 +756,228 @@ tasks.named('buildSite') {
     finalizedBy tasks.named('verifyPublicTargetHasOnlyPublishedArticles')
 }
 
+// ---------------------------------------------------------------------------
+// Private target — ADR-009, issue #86
+// ---------------------------------------------------------------------------
+// The private repository holds content and nothing else. It reaches this
+// repository's tooling through a sibling checkout, so everything below reads a
+// tree outside this project.
+//
+// That tree is optional. A checkout without the sibling is an ordinary state of
+// this repository, not a broken one, so nothing here may fail while the build
+// configures itself: that would break every Gradle invocation instead of the one
+// task that needs the sibling.
+def privateCheckoutDir = file(env('PROFILE_PRIVATE_DIR') ?: "${rootDir}/../profile-private")
+def privateContentDir = new File(privateCheckoutDir, 'src-content/profile')
+def privateSiteDir = new File(privateContentDir, 'site')
+def publicIncludesDir = file('src-content/profile/includes')
+
+// ADR-009's "no second implementation" rule, read as a question about files.
+// A copy of the schema, validator, or build keeps looking like the original
+// after it has stopped being one, which is the drift the rule removes rather
+// than detects.
+def privateSecondImplementations = { File dir ->
+    def found = ['metamodel', 'build.gradle', 'settings.gradle', 'gradlew'].findAll { new File(dir, it).exists() }
+    def scripts = new File(dir, 'scripts')
+    if (scripts.isDirectory()) {
+        found += (scripts.listFiles() ?: new File[0])
+                .findAll { it.name ==~ /^(validate|generate)-.*\.(rb|js|mjs)$/ }
+                .collect { "scripts/${it.name}" }
+                .sort()
+    }
+    found
+}
+
+def requirePrivateCheckout = { ->
+    if (!privateCheckoutDir.isDirectory()) {
+        throw new GradleException(
+                "The private content checkout was not found.\n" +
+                "  expected: ${privateCheckoutDir}\n" +
+                "  ADR-009 checks the two repositories out as siblings. Clone dieterbaier/profile-private to that\n" +
+                "  path, or set PROFILE_PRIVATE_DIR to where it already is.")
+    }
+    if (!privateSiteDir.isDirectory()) {
+        throw new GradleException(
+                "The private checkout has no content root.\n" +
+                "  checkout: ${privateCheckoutDir}\n" +
+                "  expected: ${privateSiteDir}\n" +
+                "  The private tree mirrors this repository's layout so the same tooling reads both.")
+    }
+    def found = privateSecondImplementations(privateCheckoutDir)
+    if (!found.isEmpty()) {
+        throw new GradleException(
+                "The private checkout carries its own tooling, which ADR-009 forbids:\n" +
+                found.collect { "  - ${it}" }.join('\n') + "\n" +
+                "  The private repository holds content only; schema, validators, generators, and the build stay\n" +
+                "  in this repository. Remove the copy rather than keeping it in step.")
+    }
+}
+
+// Asked of the private tree the same way the public one is asked, and only when
+// there is a tree to ask about. Without a sibling the list is empty and the
+// render task never runs, because requirePrivateCheckout stops it first.
+def privateArticleExclusions = {
+    if (!privateSiteDir.isDirectory()) {
+        return [] as Set
+    }
+
+    def stdout = new StringWriter()
+    def stderr = new StringWriter()
+    def process = ['ruby', 'scripts/validate-profile-metamodel.rb',
+                   '--list-public-source-exclusions',
+                   '--target', 'private',
+                   '--root', privateCheckoutDir.absolutePath,
+                   '--profile-dir', privateContentDir.absolutePath,
+                   '--includes-dir', publicIncludesDir.absolutePath].execute(null, rootDir)
+    process.waitForProcessOutput(stdout, stderr)
+
+    // Fail closed, as the public selection does: without a trustworthy list the
+    // safe answer is to render nothing.
+    if (process.exitValue() != 0) {
+        throw new GradleException(
+                'Could not determine which articles the private target may render.\n' +
+                        "ruby scripts/validate-profile-metamodel.rb --target private failed:\n${stderr}")
+    }
+
+    stdout.toString().readLines().findAll { !it.trim().isEmpty() }.toSet()
+}()
+
+tasks.register('checkPrivateCheckout') {
+    description = 'Verifies the sibling private checkout exists and carries no tooling of its own.'
+    group = 'verification'
+    doLast {
+        requirePrivateCheckout()
+        println "Private checkout: ${privateCheckoutDir}"
+    }
+}
+
+tasks.register('validateProfilePrivateMetamodel') {
+    description = 'Validates the private content root against this repository\'s profile metamodel.'
+    group = 'verification'
+    dependsOn tasks.named('checkPrivateCheckout')
+
+    doLast {
+        exec {
+            commandLine 'ruby', 'scripts/validate-profile-metamodel.rb',
+                    '--root', privateCheckoutDir.absolutePath,
+                    '--profile-dir', privateContentDir.absolutePath,
+                    '--includes-dir', publicIncludesDir.absolutePath
+        }
+    }
+}
+
+// The private target renders from the sibling checkout into this repository's
+// build directory. The includes stay here: the private repository owns no theme
+// and no interface terms, so the attribute is an absolute path into this tree.
+asciidoctorBase('buildSitePrivate', '', privateSiteDir, 'build/site-private', [], true, "html5", [
+                                                                        'includesdir': publicIncludesDir.absolutePath,
+                                                                        'site-address-name': env('SITE_ADDRESS_NAME') ?: '.',
+                                                                        'site-street': env('SITE_STREET') ?: '.',
+                                                                        'site-plz'   : env('SITE_PLZ') ?: '.',
+                                                                        'site-city'  : env('SITE_CITY') ?: '.',
+                                                                        'site-tel'   : env('SITE_TEL') ?: '.',
+                                                                        'site-email' : env('SITE_EMAIL') ?: '.'
+])
+tasks.named('buildSitePrivate') {
+    description = 'Renders the private content root locally, including drafts, into build/site-private.'
+    dependsOn tasks.named('validateProfilePrivateMetamodel')
+    inputs.file('scripts/inject-site-metadata.rb')
+
+    // The private target renders what exists before an article is public, and
+    // the public statuses too, so a draft is read in the same shape as a
+    // finished page. Anything outside that set is absent from the target rather
+    // than merely unlinked.
+    sources {
+        def prefix = "${privateSiteDir.absolutePath}/"
+        privateArticleExclusions.each { exclusion ->
+            // The list is relative to the private root; a source spec matches
+            // relative to its own source directory.
+            def absolute = new File(privateCheckoutDir, exclusion).absolutePath
+            if (absolute.startsWith(prefix)) {
+                exclude absolute.substring(prefix.length())
+            }
+        }
+    }
+
+    doFirst {
+        requirePrivateCheckout()
+    }
+
+    // No canonical link and a robots tag on every page. The target is read
+    // locally and deployed nowhere, and the two rules are what keep it from
+    // claiming to be the official location of anything.
+    doLast {
+        exec {
+            commandLine 'ruby', 'scripts/inject-site-metadata.rb',
+                    '--site-dir', layout.buildDirectory.dir('site-private').get().asFile,
+                    '--noindex'
+        }
+    }
+
+    finalizedBy tasks.named('verifyPrivateTargetHasOnlyAllowedArticles')
+}
+
+// Checks the rendered result rather than the selection that produced it, the
+// same way the public target is checked. The private target is allowed more
+// statuses, not any status.
+tasks.register('verifyPrivateTargetHasOnlyAllowedArticles') {
+    description = 'Fails when build/site-private holds output of an article that target must not carry.'
+    group = 'verification'
+
+    doLast {
+        requirePrivateCheckout()
+        exec {
+            commandLine 'ruby', 'scripts/validate-profile-metamodel.rb',
+                    '--verify-public-target-output',
+                    '--target', 'private',
+                    '--root', privateCheckoutDir.absolutePath,
+                    '--profile-dir', privateContentDir.absolutePath,
+                    '--includes-dir', publicIncludesDir.absolutePath,
+                    '--output-root', rootDir.absolutePath
+        }
+    }
+}
+
+tasks.register('testProfileMetadataVersion') {
+    description = 'Runs the metadata contract version behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'metamodel/profile-artifact.schema.yaml',
+                 'test/profile_metadata_version_test.rb', 'features/metadata-contract-version.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_metadata_version_test.rb'
+        }
+    }
+}
+
+tasks.register('testProfilePrivateTarget') {
+    description = 'Runs the private content target behaviour tests.'
+    group = 'verification'
+    inputs.files('scripts/validate-profile-metamodel.rb', 'scripts/inject-site-metadata.rb',
+                 'test/profile_private_target_test.rb', 'features/private-content-target.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/profile_private_target_test.rb'
+        }
+    }
+}
+
+// Invokes the build itself, because the sibling-checkout rules live in the
+// build. Kept in its own task so the fast metadata suites stay fast.
+tasks.register('testPrivateCheckoutContract') {
+    description = 'Runs the sibling private checkout contract tests.'
+    group = 'verification'
+    inputs.files('build.gradle', 'test/private_checkout_contract_test.rb', 'features/private-content-target.feature')
+
+    doLast {
+        exec {
+            commandLine 'ruby', '-Itest', 'test/private_checkout_contract_test.rb'
+        }
+    }
+}
+
 tasks.register('testSiteMetadata') {
     description = 'Runs the canonical public-site metadata behaviour tests.'
     group = 'verification'

--- a/build.sh
+++ b/build.sh
@@ -45,6 +45,21 @@ for var in "${PASS_ENV[@]}"; do
     fi
 done
 
+# The private content root is a sibling checkout, which means it sits outside
+# $PWD and is therefore not in the container unless it is mounted. Without this,
+# ./gradlew and ./build.sh disagree about whether the private target can be
+# built at all, and the container reports a missing sibling that is present on
+# the host.
+#
+# Mounted only when it exists: a checkout without the sibling is an ordinary
+# state of this repository, and Podman fails on a missing bind-mount source
+# rather than creating it.
+PRIVATE_ARGS=()
+PRIVATE_DIR="${PROFILE_PRIVATE_DIR:-$PWD/../profile-private}"
+if [ -d "$PRIVATE_DIR" ]; then
+    PRIVATE_ARGS=(-v "$(cd "$PRIVATE_DIR" && pwd)":/private -e PROFILE_PRIVATE_DIR=/private)
+fi
+
 # Gradle cache location. Defaults to a named volume for local reuse; CI overrides
 # it with a host path (for example $HOME/.gradle) so actions/cache can persist it.
 GRADLE_CACHE="${GRADLE_CACHE:-gradle-cache}"
@@ -61,6 +76,7 @@ $ENGINE run --rm \
     $ENV_FILE \
     "${ENV_ARGS[@]}" \
     -v "$PWD":/app \
+    "${PRIVATE_ARGS[@]}" \
     -v "$GRADLE_CACHE":/root/.gradle \
     -w /app \
     "$IMAGE_NAME" \

--- a/features/private-content-target.feature
+++ b/features/private-content-target.feature
@@ -1,0 +1,93 @@
+# Living documentation for rendering the private content root locally.
+#
+# Bridged to two files, because the rules live in two places (classic Minitest,
+# no native BDD runner in this repository). Each scenario maps to a test method
+# named after the sanitized scenario title, with Given/When/Then comment anchors
+# inside it. Traceability is a reviewer-verifiable convention, not a
+# build-enforced link.
+#
+#   test/profile_private_target_test.rb      - selection, interface terms, noindex
+#   test/private_checkout_contract_test.rb   - the sibling-checkout contract, which
+#                                              lives in the build and is therefore
+#                                              verified by running the build
+#
+# The rules come from ADR-009 and ADR-008. The private repository holds content
+# and nothing else; it reaches this repository's tooling through a sibling
+# checkout. The target that results is read locally and deployed nowhere, which
+# is why it may carry drafts and why every page in it must say that it is not
+# the official location of anything.
+
+Feature: Private content target
+  As the owner of the profile publishing system
+  I want the private repository's content rendered with this repository's tooling
+  So that I can read a draft as a finished page before deciding anything about it
+
+  Scenario: The private target renders drafts alongside published articles
+    Given private, preview, and published articles in the private content root
+    When the private article selection is computed
+    Then none of their sources is excluded from the private target
+
+  Scenario: A status that belongs to no target is kept out of the private one
+    Given articles with the statuses draft, proposed, reviewed, archived, and deprecated
+    When the private article selection is computed
+    Then every one of their sources is excluded from the private target
+
+  Scenario: An article the private target renders is still absent from the public one
+    Given a private article and a preview article
+    When the public article selection is computed
+    Then both of their sources are excluded from the public target
+
+  Scenario: Interface terms come from the tree that owns them
+    Given a content root without interface terms and a separate tree that has them
+    When the profile metadata is validated against that includes tree
+    Then validation passes without the content root holding a copy
+
+  Scenario: A content root with no interface terms anywhere stops the build
+    Given a content root and an includes tree that both lack interface terms
+    When the profile metadata is validated
+    Then validation fails naming the interface terms it expected
+
+  Scenario: Every page of the private target is marked as not to be indexed
+    Given a rendered target whose pages carry a canonical link
+    When the target is marked as not indexed
+    Then every page carries a robots noindex tag and no canonical link
+
+  Scenario: Marking a target twice leaves one robots tag
+    Given a rendered target that was already marked as not indexed
+    When the target is marked as not indexed again
+    Then each page carries exactly one robots tag
+
+  Scenario: A target cannot be both unindexed and canonical
+    Given a request to mark a target as not indexed
+    When a base URL is supplied with it
+    Then the request is refused rather than resolved in favour of one of them
+
+  Scenario: Output of an article the private target must not contain is reported
+    Given a rendered private target holding the page of a draft article
+    When the rendered target is checked against the private status set
+    Then that page is reported
+
+  Scenario: The private target is checked where it is rendered, not where its content lives
+    Given private content in one tree and its rendered target in another
+    When the rendered target is checked
+    Then the reported path is relative to the tree holding the target
+
+  Scenario: A missing sibling checkout names the path it expected
+    Given no checkout at the configured path
+    When the private target is asked for
+    Then the build stops naming what it expected and where
+
+  Scenario: A checkout without a content root names the directory it expected
+    Given a checkout that exists but carries no content root
+    When the private target is asked for
+    Then the build stops naming the content root it expected
+
+  Scenario: A checkout carrying its own tooling stops the build
+    Given a private checkout with a schema of its own
+    When the private target is asked for
+    Then the build stops and names the copy it found
+
+  Scenario: An absent sibling leaves the rest of the build alone
+    Given no private checkout at the configured path
+    When a task that has nothing to do with the private target runs
+    Then it succeeds, because a checkout without the sibling is an ordinary state

--- a/features/private-content-target.feature
+++ b/features/private-content-target.feature
@@ -91,3 +91,13 @@ Feature: Private content target
     Given no private checkout at the configured path
     When a task that has nothing to do with the private target runs
     Then it succeeds, because a checkout without the sibling is an ordinary state
+
+  Scenario: An unreadable sibling leaves the rest of the build alone
+    Given a private checkout whose content cannot be resolved
+    When a task that has nothing to do with the private target runs
+    Then it succeeds, because the private selection is not that task's business
+
+  Scenario: An unreadable sibling stops the private target
+    Given a private checkout whose content cannot be resolved
+    When the private target is built
+    Then the build stops naming the content it could not resolve

--- a/scripts/inject-site-metadata.rb
+++ b/scripts/inject-site-metadata.rb
@@ -5,6 +5,52 @@ require 'optparse'
 require 'pathname'
 require 'uri'
 
+# Marks every page of a target as one search engines must not index, and strips
+# any canonical link it carries.
+#
+# The two belong together. A target that says "do not index me" while also
+# claiming to be the canonical location of its content states two opposite
+# things about the same page, and which one wins is the search engine's choice
+# rather than ours. ADR-008 requires both for the preview and private targets.
+#
+# This is a signal, not a control: the pages are readable by anyone who has the
+# URL. Nothing here may be relied on for confidentiality.
+class RobotsNoindexInjector
+  ROBOTS_TAG = '<meta name="robots" content="noindex, nofollow">'
+  ROBOTS_PATTERN = %r{<meta\b[^>]*\bname\s*=\s*["']robots["'][^>]*>}i
+  CANONICAL_PATTERN = %r{<link\b[^>]*\brel\s*=\s*["']canonical["'][^>]*>\n?}i
+
+  attr_reader :site_dir
+
+  def initialize(site_dir:)
+    @site_dir = Pathname.new(site_dir).expand_path
+  end
+
+  # Returns the pages it marked, so a caller can report a number it produced
+  # rather than one it assumed.
+  def inject
+    Pathname.glob(site_dir.join('**/*.html')).sort.select { |path| inject_file(path) }
+  end
+
+  private
+
+  def inject_file(html_path)
+    content = html_path.read(encoding: 'UTF-8')
+    return false unless content.include?('</head>')
+
+    updated = content.gsub(CANONICAL_PATTERN, '')
+    # Idempotent: re-running replaces the tag instead of stacking copies.
+    updated = if updated.match?(ROBOTS_PATTERN)
+                updated.sub(ROBOTS_PATTERN) { ROBOTS_TAG }
+              else
+                updated.sub('</head>') { "#{ROBOTS_TAG}\n</head>" }
+              end
+
+    html_path.write(updated, encoding: 'UTF-8')
+    true
+  end
+end
+
 class SiteMetadataInjector
   attr_reader :site_dir, :base_url, :alternates, :default_language
 
@@ -115,7 +161,22 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--base-url URL') { |value| options[:base_url] = value }
     parser.on('--required') { options[:required] = true }
     parser.on('--alternates PATH') { |value| options[:alternates] = value }
+    parser.on('--noindex') { options[:noindex] = true }
   end.parse!
+
+  # A target is either the canonical home of its content or one that must not be
+  # indexed. Asking for both is a contradiction the build should not resolve
+  # silently by preferring one of them.
+  if options[:noindex]
+    abort '--site-dir is required' unless options[:site_dir]
+    if options[:base_url] && !options[:base_url].strip.empty?
+      abort '--noindex and --base-url are mutually exclusive: a target that is not indexed claims no canonical URL'
+    end
+
+    marked = RobotsNoindexInjector.new(site_dir: options[:site_dir]).inject
+    puts "Marked #{marked.length} page(s) as noindex, without canonical links."
+    exit 0
+  end
 
   if options[:base_url].nil? || options[:base_url].strip.empty?
     abort 'SITE_BASE_URL is required for this build' if options[:required]

--- a/scripts/validate-profile-metamodel.rb
+++ b/scripts/validate-profile-metamodel.rb
@@ -25,8 +25,15 @@ class ProfileArtifactValidator
   # wider definition here meant the repository held two answers to "is this
   # article public", and the stricter one was the one reaching an external
   # system.
+  #
+  # 'private' is the local reading target for the private repository. It carries
+  # the statuses that exist before an article is public, plus the public ones, so
+  # that the owner reads a draft in the same shape as a finished page. It is not
+  # a deployment: the target is rendered locally and never published, which is
+  # why a wider status set is safe here and would not be above.
   TARGET_STATUSES = {
-    'public' => %w[published].freeze
+    'public' => %w[published].freeze,
+    'private' => %w[private preview published].freeze
   }.freeze
   # Statuses whose articles are part of the public site: rendered, listed,
   # navigable, and offered as related-article suggestions.
@@ -102,11 +109,18 @@ class ProfileArtifactValidator
   end
 
   Artifact = Struct.new(:path, :metadata, keyword_init: true)
-  attr_reader :errors, :warnings, :root, :profile_dir
+  attr_reader :errors, :warnings, :root, :profile_dir, :includes_dir
 
-  def initialize(root:, profile_dir:)
+  # `includes_dir` is where the shared interface terms, images, and docheader
+  # live. It defaults to the content root's own `includes`, which is what the
+  # public tree has. A content root that owns no includes passes the tree that
+  # does: ADR-009 lets the private repository hold content only, so its build
+  # reads the public checkout's includes rather than keeping a copy that would
+  # drift.
+  def initialize(root:, profile_dir:, includes_dir: nil)
     @root = Pathname.new(root).expand_path
     @profile_dir = Pathname.new(profile_dir).expand_path
+    @includes_dir = Pathname.new(includes_dir || @profile_dir.join('includes')).expand_path
     @errors = []
     @warnings = []
   end
@@ -259,6 +273,18 @@ class ProfileArtifactValidator
     { source_dir: 'src-content/profile/site/articles', output_dir: 'build/articles', extension: '.md' }
   ].freeze
 
+  # The private target renders to HTML only and has no markdown export, because
+  # nothing consumes one: the export exists so the public articles can be
+  # published elsewhere, and a private draft is published nowhere.
+  PRIVATE_RENDER_ROOTS = [
+    { source_dir: 'src-content/profile/site', output_dir: 'build/site-private', extension: '.html' }
+  ].freeze
+
+  TARGET_RENDER_ROOTS = {
+    'public' => RENDER_ROOTS,
+    'private' => PRIVATE_RENDER_ROOTS
+  }.freeze
+
   # Outputs present in a rendered target that belong to an article the target
   # must not contain.
   #
@@ -266,15 +292,23 @@ class ProfileArtifactValidator
   # with the exclusion list — applied it, mis-applied it, or was invoked in a
   # way that skipped it — an article that must not be public either has output
   # here or it does not.
-  def unexpected_target_outputs(artifacts, target:, render_roots: RENDER_ROOTS)
+  #
+  # `output_root` is where the rendered target lives, which is not always the
+  # root the content came from. The private target is rendered by the public
+  # checkout into its own build directory, so its sources are relative to the
+  # private root while its output is relative to the public one.
+  def unexpected_target_outputs(artifacts, target:, render_roots: nil, output_root: nil)
+    render_roots ||= TARGET_RENDER_ROOTS.fetch(target, RENDER_ROOTS)
+    output_root = Pathname.new(output_root || root).expand_path
+
     excluded_article_sources(artifacts, target: target).flat_map do |source|
       render_roots.filter_map do |render_root|
         prefix = "#{render_root[:source_dir]}/"
         next unless source.start_with?(prefix)
 
         rendered = source.delete_prefix(prefix).sub(/\.adoc\z/, render_root[:extension])
-        candidate = root.join(render_root[:output_dir], rendered)
-        relative(candidate) if candidate.exist?
+        candidate = output_root.join(render_root[:output_dir], rendered)
+        relative_to(candidate, output_root) if candidate.exist?
       end
     end.uniq.sort
   end
@@ -666,7 +700,7 @@ class ProfileArtifactValidator
   # the relative paths the local and PDF builds rely on; root-relative URLs would
   # have broken both.
   def generate_link_registries(artifacts)
-    registry_dir = profile_dir.join('includes', 'generated', 'i18n')
+    registry_dir = includes_dir.join('generated', 'i18n')
     FileUtils.rm_rf(registry_dir)
     FileUtils.mkdir_p(registry_dir)
 
@@ -1153,7 +1187,7 @@ class ProfileArtifactValidator
   # mixed languages. This walks the include tree of every page and rejects any
   # fragment that is not available in the page's own language.
   def validate_fragment_languages
-    fragment_root = profile_dir.join('includes', 'i18n')
+    fragment_root = includes_dir.join('i18n')
 
     pages = page_sources
     pages.each do |page, language|
@@ -1185,7 +1219,7 @@ class ProfileArtifactValidator
   # ask for more translations than a build needs, never fewer.
   def walk_includes(page, language, fragment_root)
     visited = Set.new
-    queue = [[page, { 'includesdir' => profile_dir.join('includes').to_s, 'lang' => language }]]
+    queue = [[page, { 'includesdir' => includes_dir.to_s, 'lang' => language }]]
 
     until queue.empty?
       current, attributes = queue.shift
@@ -1388,7 +1422,7 @@ class ProfileArtifactValidator
   # back to the default language and say so, but a menu label or a status message
   # has nowhere to say it, so a missing key is an error rather than a fallback.
   def validate_ui_terms(artifacts)
-    i18n_dir = profile_dir.join('includes', 'i18n')
+    i18n_dir = includes_dir.join('i18n')
 
     # Checked without testing the directory first: docheader.adoc includes the
     # default terms unconditionally, so a missing directory breaks every page and
@@ -1460,7 +1494,7 @@ class ProfileArtifactValidator
   # translates. Used where a value has to be baked into generated output because
   # no page header is available to resolve an attribute reference.
   def ui_terms_values(language)
-    i18n_dir = profile_dir.join('includes', 'i18n')
+    i18n_dir = includes_dir.join('i18n')
     [DEFAULT_LANGUAGE, language].uniq.each_with_object({}) do |candidate, terms|
       path = ui_terms_path(i18n_dir, candidate)
       next unless path.file?
@@ -1994,7 +2028,14 @@ class ProfileArtifactValidator
   end
 
   def relative(path)
-    Pathname.new(path).expand_path.relative_path_from(root).to_s
+    relative_to(path, root)
+  end
+
+  # Paths are reported relative to the tree they belong to. A rendered target may
+  # live under a different root than the content that produced it, so the base is
+  # passed in rather than always being `root`.
+  def relative_to(path, base)
+    Pathname.new(path).expand_path.relative_path_from(Pathname.new(base).expand_path).to_s
   rescue ArgumentError
     path.to_s
   end
@@ -2011,7 +2052,10 @@ if $PROGRAM_NAME == __FILE__
     accept_translation: nil,
     language_alternates: nil,
     list_public_source_exclusions: false,
-    verify_public_target_output: false
+    verify_public_target_output: false,
+    includes_dir: nil,
+    target: 'public',
+    output_root: nil
   }
   OptionParser.new do |parser|
     parser.on('--root PATH') { |value| options[:root] = Pathname.new(value) }
@@ -2023,13 +2067,30 @@ if $PROGRAM_NAME == __FILE__
     parser.on('--language-alternates PATH') { |value| options[:language_alternates] = value }
     parser.on('--list-public-source-exclusions') { options[:list_public_source_exclusions] = true }
     parser.on('--verify-public-target-output') { options[:verify_public_target_output] = true }
+    # Where the shared includes live. A content root that owns none - the private
+    # repository, per ADR-009 - points at the tree that does.
+    parser.on('--includes-dir PATH') { |value| options[:includes_dir] = Pathname.new(value) }
+    # Which publication target the selection and output questions are about.
+    parser.on('--target NAME') { |value| options[:target] = value }
+    # Where the rendered target lives, when that is not the content root.
+    parser.on('--output-root PATH') { |value| options[:output_root] = Pathname.new(value) }
   end.parse!
 
   root = options[:root]
   profile_dir = options[:profile_dir] || root.join('src-content/profile')
   output = options[:output] || 'src-content/profile/generated/profile-artifact-index.adoc'
 
-  validator = ProfileArtifactValidator.new(root: root, profile_dir: profile_dir)
+  target = options[:target]
+  unless ProfileArtifactValidator::TARGET_STATUSES.key?(target)
+    warn "unknown target '#{target}'; known targets: #{ProfileArtifactValidator::TARGET_STATUSES.keys.join(', ')}"
+    exit(1)
+  end
+
+  validator = ProfileArtifactValidator.new(
+    root: root,
+    profile_dir: profile_dir,
+    includes_dir: options[:includes_dir]
+  )
 
   # Answers the build's question about publication selection and nothing else.
   # It reports no findings and fails on no metadata error, because the build
@@ -2037,7 +2098,7 @@ if $PROGRAM_NAME == __FILE__
   # Gradle invocation instead of the validator task that owns that report.
   if options[:list_public_source_exclusions]
     begin
-      puts validator.excluded_article_sources(validator.scan_artifacts, target: 'public')
+      puts validator.excluded_article_sources(validator.scan_artifacts, target: target)
     rescue ProfileArtifactValidator::UnresolvableArticleSource => e
       warn "Publication selection failed: #{e.message}"
       exit(1)
@@ -2050,18 +2111,23 @@ if $PROGRAM_NAME == __FILE__
   # selection.
   if options[:verify_public_target_output]
     begin
-      unexpected = validator.unexpected_target_outputs(validator.scan_artifacts, target: 'public')
+      unexpected = validator.unexpected_target_outputs(
+        validator.scan_artifacts,
+        target: target,
+        output_root: options[:output_root]
+      )
     rescue ProfileArtifactValidator::UnresolvableArticleSource => e
       warn "Publication selection failed: #{e.message}"
       exit(1)
     end
 
     if unexpected.empty?
-      puts 'Public target contains no output of a non-published article.'
+      puts "The '#{target}' target contains no output of an article it must not carry."
       exit(0)
     end
 
-    warn "Public target contains output of #{unexpected.length} article(s) that are not published:"
+    warn "The '#{target}' target contains output of #{unexpected.length} article(s) it must not carry " \
+         "(accepted statuses: #{ProfileArtifactValidator::TARGET_STATUSES.fetch(target).join(', ')}):"
     unexpected.each { |path| warn "  - #{path}" }
     exit(1)
   end

--- a/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-009-private-repository-integration.adoc
@@ -185,14 +185,16 @@ The decision holds; the rules it accepts are at different stages, and this secti
 [cols="2,1,2", options="header"]
 |===
 | Rule | State | Where
-| Sibling checkout as the tooling access mechanism | decided, not implemented | The private build, https://github.com/dieterbaier/profile/issues/86[#86]
-| No second implementation in the private repository | decided, not implemented | Checked by the private build, https://github.com/dieterbaier/profile/issues/86[#86], and by the promotion checks, https://github.com/dieterbaier/profile/issues/84[#84]
+| Sibling checkout as the tooling access mechanism | implemented | `buildSitePrivate` in `build.gradle`, resolved from `PROFILE_PRIVATE_DIR` or the sibling path, https://github.com/dieterbaier/profile/issues/86[#86]
+| No second implementation in the private repository | implemented for the private build | `checkPrivateCheckout` stops the build when the checkout carries a schema, validator, generator, or build of its own, https://github.com/dieterbaier/profile/issues/86[#86]. The promotion checks still have to apply it, https://github.com/dieterbaier/profile/issues/84[#84]
 | `metadata_version` accepted-version set enforced | implemented | Declared in `metamodel/profile-artifact.schema.yaml`, enforced by `scripts/validate-profile-metamodel.rb`, https://github.com/dieterbaier/profile/issues/83[#83]
 | Promotion saga: validate, then public, then private | decided, not implemented | https://github.com/dieterbaier/profile/issues/84[#84] and https://github.com/dieterbaier/profile/issues/85[#85]
 | Private deployment runs locally | decided, not implemented | https://github.com/dieterbaier/profile/issues/87[#87]
 |===
 
-`metadata_version` is required on every artifact, and the validator rejects a version outside the accepted set by name. Both drift rules are therefore in force for content, and what remains unbuilt is the private build that would use them.
+`metadata_version` is required on every artifact, and the validator rejects a version outside the accepted set by name. Both drift rules are in force, and the private build applies them: `buildSitePrivate` validates the private content root with this repository's validator before rendering it, and reads the accepted versions from this checkout rather than from the tree beside the content.
+
+What the private build does not yet do is run the generators against the private tree, so a private page carries no tags, no article navigation, and no series links. The generators write link registries into the includes tree, which for the private target is this repository's — a generator run would write into the public checkout while rendering private content. That is a real coupling and not a detail of wiring, so it is left to a slice of its own rather than solved in passing.
 
 **This was the gate on private-source work.** No slice that reads private source or promotes an article was to run before the accepted-version check existed, because a promotion validated against an unenforced contract is the exact failure this decision claims to prevent. https://github.com/dieterbaier/profile/issues/83[#83] closed that gate; the remaining private slices are ordered by their own dependencies.
 

--- a/src-content/docs/arc42/09-architecture-decisions/adr-012-private-reading-context.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-012-private-reading-context.adoc
@@ -1,0 +1,154 @@
+---
+id: ADR-012-private-reading-context
+type: ADR
+title: "Reading Context of the Private Target"
+status: proposed
+owner: "Dieter Baier"
+created: '2026-08-04'
+reviewed: false
+generated: false
+summary: "Render the private target from the public site tree together with the private content root, so a draft is read inside the site it will live in rather than on its own."
+tags:
+- adr
+- decision
+- publishing
+- article-lifecycle
+relations:
+- type: refines
+  target: ADR-008-private-to-public-article-lifecycle
+  status: proposed
+  rationale: "ADR-008 names the private target and its visibility rules but does not say what a page in it is surrounded by."
+  reviewed: false
+- type: depends_on
+  target: ADR-009-private-repository-integration
+  status: proposed
+  rationale: "The private repository holds content only, which is why the surrounding site has to come from somewhere else."
+  reviewed: false
+- type: introduces_risk
+  target: RISK-003-private-data-exposure
+  status: proposed
+  rationale: "A target that renders as a complete site is easier to mistake for a deployable one while it contains unpublished drafts."
+  reviewed: false
+metadata_version: '1.0'
+---
+[[adr-012-private-reading-context]]
+== ADR-012: Reading Context of the Private Target
+
+=== Status
+
+Proposed. Drafted after the first private render in
+https://github.com/dieterbaier/profile/issues/86[GitHub issue #86] showed the
+question, and not yet accepted.
+
+=== Decision
+
+The private target is rendered from the public site tree **and** the private
+content root together, into one output. A draft is read inside the site it will
+live in: the same menu, the same start page, the same legal notice, the same
+article listings.
+
+The private content root wins where both trees offer the same output path, so a
+draft can stand in for a page that already exists publicly without the public
+copy hiding it.
+
+=== Context
+
+ADR-009 gives the private repository content and nothing else. The first private
+render therefore produced exactly what the private repository contains: three
+article pages, the theme, and no site around them. Every link in the page chrome
+— start page, CV, legal notice, article listings, language switcher — points at a
+file that is not in the target.
+
+The target exists so that a draft can be read as a finished page before anything
+is decided about it. A page whose navigation is entirely broken is not the page
+being decided about, and the reader has to hold in their head which of the
+defects are the draft's and which are the target's.
+
+**The preview target does not have this problem**, and the difference is worth
+stating so the two are not solved twice. Promotion moves an article into the
+public repository and sets `status: preview` there. `build/site-preview` is built
+from public source only, as
+https://github.com/dieterbaier/profile/issues/78[#78] specifies, so it already
+contains the whole public site plus the preview articles. Only the private
+target reads from a tree that holds articles alone.
+
+The cheap answer — leave it as it is — is not obviously wrong. The private target
+is read by one person who knows why the links fail, and rendering the entire
+public site to look at three drafts is a real cost on every run.
+
+=== Options
+
+[.pugh-matrix]
+[cols="3,1,1,1,1", options="header"]
+|===
+| Criterion | Compose public site and private content | Private content only | Generated minimal shell | Read only after promotion to preview
+| A draft is read as the page it will become | +1 | -1 | 0 | +1
+| Links in the site chrome resolve | +1 | -1 | 0 | +1
+| An unfinished article is not published in order to read it | +1 | +1 | +1 | -1
+| A draft is read without leaving the private repository | +1 | +1 | +1 | -1
+| No invented structure that matches no real site | +1 | +1 | -1 | +1
+| Cost of one private render | -1 | +1 | 0 | +1
+| Failure modes are easy to reason about | 0 | +1 | -1 | +1
+s| Sum s| +4 s| +3 s| 0 s| +3
+|===
+
+*Compose public site and private content* renders both trees into one target.
+The surrounding site is the real one rather than a stand-in, and it costs a full
+public render on every private build.
+
+*Private content only* is what #86 built. It is the cheapest and the most
+predictable, and it is the option whose output most obviously must never be
+deployed, because it plainly is not a site.
+
+*Generated minimal shell* would produce just enough index and menu targets for
+the links to resolve. It invents a structure that matches no real site, so a
+draft would be read inside a fourth thing that exists only in this target.
+
+*Read only after promotion to preview* removes the private reading target
+entirely. It scores well on everything except the reason the private path exists:
+the article would be publicly reachable — ADR-011 removed the access boundary in
+front of preview — before its author has read it as a page once.
+
+=== Consequences
+
+Positive:
+
+* A draft is read in the context that decides whether it works, not in isolation.
+* The private and preview readings have the same shape, so what the private read
+  shows carries over to the preview one.
+* No structure is invented for this target; the context is the public site as it
+  actually is.
+
+Negative:
+
+* Every private render also renders the public site, which is most of the build
+  time for three drafts.
+* The output looks like a complete, deployable site while containing unpublished
+  content. That is the risk this record introduces, and it is the reason the
+  target keeps `noindex` on every page and is deployed by nothing.
+* A composition rule is now part of the build: two trees, one output, and a
+  defined winner. That is one more thing to understand when the target surprises
+  someone.
+
+=== Open Questions For Review
+
+. **Collision rule.** The decision above says the private tree wins. The
+  alternative — fail the build on a collision — would catch a draft that
+  accidentally shadows a published page. Which is wanted is not obvious, and the
+  answer belongs in this record before it is accepted.
+. **Whether the public articles appear in the private target's listings.** The
+  private status set includes `published`, so they would. That is probably right,
+  and it means the listings in the private target are longer than the ones in the
+  private repository's own content.
+. **What keeps the merged output from being deployed.** Today nothing deploys it
+  and `noindex` is on every page. Whether that is enough once the output looks
+  like a whole site is a question for this record rather than for the slice that
+  implements it.
+
+=== Implementation Status
+
+Not implemented. https://github.com/dieterbaier/profile/issues/86[#86] built the
+*private content only* option, which is the second column of the matrix above. If
+this record is accepted, that behaviour changes and the change belongs to its own
+slice rather than to #86, which is already complete against its own acceptance
+criteria.

--- a/src-content/docs/arc42/09-architecture-decisions/adr-012-private-reading-context.adoc
+++ b/src-content/docs/arc42/09-architecture-decisions/adr-012-private-reading-context.adoc
@@ -2,12 +2,12 @@
 id: ADR-012-private-reading-context
 type: ADR
 title: "Reading Context of the Private Target"
-status: proposed
+status: accepted
 owner: "Dieter Baier"
 created: '2026-08-04'
-reviewed: false
+reviewed: true
 generated: false
-summary: "Render the private target from the public site tree together with the private content root, so a draft is read inside the site it will live in rather than on its own."
+summary: "Render the private target from private source alone, with this repository's theme and page chrome, and accept that links out of it do not resolve; collisions with public source are an error and the pipeline keeps non-public targets away from the public deployment."
 tags:
 - adr
 - decision
@@ -16,19 +16,19 @@ tags:
 relations:
 - type: refines
   target: ADR-008-private-to-public-article-lifecycle
-  status: proposed
+  status: accepted
   rationale: "ADR-008 names the private target and its visibility rules but does not say what a page in it is surrounded by."
-  reviewed: false
+  reviewed: true
 - type: depends_on
   target: ADR-009-private-repository-integration
-  status: proposed
-  rationale: "The private repository holds content only, which is why the surrounding site has to come from somewhere else."
-  reviewed: false
-- type: introduces_risk
-  target: RISK-003-private-data-exposure
-  status: proposed
-  rationale: "A target that renders as a complete site is easier to mistake for a deployable one while it contains unpublished drafts."
-  reviewed: false
+  status: accepted
+  rationale: "The private repository holds content only, which is why the surrounding site is not there to render."
+  reviewed: true
+- type: mitigates
+  target: RISK-004-source-boundary-leakage
+  status: accepted
+  rationale: "Keeping non-public targets away from the public deployment is placed in the pipeline, where the directory a job publishes is decided."
+  reviewed: true
 metadata_version: '1.0'
 ---
 [[adr-012-private-reading-context]]
@@ -36,119 +36,144 @@ metadata_version: '1.0'
 
 === Status
 
-Proposed. Drafted after the first private render in
-https://github.com/dieterbaier/profile/issues/86[GitHub issue #86] showed the
-question, and not yet accepted.
+Accepted by the site owner on 2026-08-04, after the first private render in
+https://github.com/dieterbaier/profile/issues/86[GitHub issue #86] raised the
+question.
 
 === Decision
 
-The private target is rendered from the public site tree **and** the private
-content root together, into one output. A draft is read inside the site it will
-live in: the same menu, the same start page, the same legal notice, the same
-article listings.
+The private target is rendered from the private content root alone, with this
+repository's theme, includes, and page chrome. A draft is read as a styled page,
+and links that leave it — start page, CV, legal notice, article listings — do not
+resolve, because their targets are not in this repository.
 
-The private content root wins where both trees offer the same output path, so a
-draft can stand in for a page that already exists publicly without the public
-copy hiding it.
+That is accepted rather than worked around. If it turns out to obstruct reading,
+this record is superseded rather than amended.
+
+Two rules come with it:
+
+* **A collision between private and public source is an error**, reported as
+  early as it can be seen rather than when an article is promoted.
+* **The pipeline keeps non-public targets away from the public deployment.** The
+  safeguard is in CI, not in the shape of the rendered output.
 
 === Context
 
 ADR-009 gives the private repository content and nothing else. The first private
-render therefore produced exactly what the private repository contains: three
-article pages, the theme, and no site around them. Every link in the page chrome
-— start page, CV, legal notice, article listings, language switcher — points at a
-file that is not in the target.
+render therefore produced what the private repository contains: three article
+pages and the theme, with no site around them. Every link in the page chrome
+points at a file that is not in the target.
 
-The target exists so that a draft can be read as a finished page before anything
-is decided about it. A page whose navigation is entirely broken is not the page
-being decided about, and the reader has to hold in their head which of the
-defects are the draft's and which are the target's.
+The target exists so a draft can be read as a finished page before anything is
+decided about it. The open question was whether "as a finished page" requires the
+finished site around it.
 
-**The preview target does not have this problem**, and the difference is worth
-stating so the two are not solved twice. Promotion moves an article into the
-public repository and sets `status: preview` there. `build/site-preview` is built
-from public source only, as
-https://github.com/dieterbaier/profile/issues/78[#78] specifies, so it already
-contains the whole public site plus the preview articles. Only the private
-target reads from a tree that holds articles alone.
-
-The cheap answer — leave it as it is — is not obviously wrong. The private target
-is read by one person who knows why the links fail, and rendering the entire
-public site to look at three drafts is a real cost on every run.
+**The preview target does not have this problem**, and stating that here keeps it
+from being solved twice. Promotion moves an article into the public repository
+and sets `status: preview` there. `build/site-preview` is built from public
+source only, as https://github.com/dieterbaier/profile/issues/78[#78] specifies,
+so it already contains the whole public site plus the preview articles. Only the
+private target reads from a tree that holds articles alone.
 
 === Options
 
 [.pugh-matrix]
 [cols="3,1,1,1,1", options="header"]
 |===
-| Criterion | Compose public site and private content | Private content only | Generated minimal shell | Read only after promotion to preview
-| A draft is read as the page it will become | +1 | -1 | 0 | +1
-| Links in the site chrome resolve | +1 | -1 | 0 | +1
+| Criterion | Private content only | Compose public site and private content | Generated minimal shell | Read only after promotion to preview
+| A draft is read as the page it will become | -1 | +1 | 0 | +1
+| Links in the site chrome resolve | -1 | +1 | 0 | +1
 | An unfinished article is not published in order to read it | +1 | +1 | +1 | -1
 | A draft is read without leaving the private repository | +1 | +1 | +1 | -1
 | No invented structure that matches no real site | +1 | +1 | -1 | +1
-| Cost of one private render | -1 | +1 | 0 | +1
-| Failure modes are easy to reason about | 0 | +1 | -1 | +1
-s| Sum s| +4 s| +3 s| 0 s| +3
+| Cost of one private render | +1 | -1 | 0 | +1
+| Failure modes are easy to reason about | +1 | 0 | -1 | +1
+s| Sum s| +3 s| +4 s| 0 s| +3
 |===
 
-*Compose public site and private content* renders both trees into one target.
-The surrounding site is the real one rather than a stand-in, and it costs a full
-public render on every private build.
+*Private content only* is what #86 built and what this record accepts. It is the
+cheapest and the most predictable, and its output is plainly not a site.
 
-*Private content only* is what #86 built. It is the cheapest and the most
-predictable, and it is the option whose output most obviously must never be
-deployed, because it plainly is not a site.
+*Compose public site and private content* renders both trees into one target. It
+scores one point higher, and the point it wins is the reading context.
 
 *Generated minimal shell* would produce just enough index and menu targets for
 the links to resolve. It invents a structure that matches no real site, so a
 draft would be read inside a fourth thing that exists only in this target.
 
 *Read only after promotion to preview* removes the private reading target
-entirely. It scores well on everything except the reason the private path exists:
-the article would be publicly reachable — ADR-011 removed the access boundary in
-front of preview — before its author has read it as a page once.
+entirely. It scores well until the criterion that matters: the article would be
+publicly reachable — ADR-011 removed the access boundary in front of preview —
+before its author had read it as a page once.
+
+=== Why The Matrix Did Not Decide It
+
+The chosen option is not the highest-scoring one, and the difference is a single
+point on seven criteria. The owner weighed the two criteria that separate them —
+reading context against cost and predictability — and judged the broken chrome
+tolerable for a target read by the person who wrote its content and knows why the
+links fail.
+
+The matrix is kept as it was scored rather than re-weighted to agree with the
+outcome. A matrix adjusted until it produces the decision already made records
+nothing.
+
+=== Review Outcome
+
+The site owner accepted the decision and answered all three open questions:
+
+* **Collision rule: error, as early as possible.** The alternative — discovering
+  it when an article becomes reviewable or public — puts the collision at the
+  moment the article is being written into the public repository, which is the
+  worst time to find it. The owner is the only author, so a collision is a
+  mistake rather than a coordination event; if several people ever draft here,
+  the same check is what makes that safe. Implemented by
+  https://github.com/dieterbaier/profile/issues/94[#94].
+* **Public articles in the private listings: accepted.** The private status set
+  includes `published`, so they appear. Nothing about that needs a rule.
+* **Protection against deployment: in the pipeline.** The owner does not regard
+  the merged-looking output as the danger. What must hold is that CI never
+  publishes the private or the preview target to the public destination, which
+  is https://github.com/dieterbaier/profile/issues/95[#95].
 
 === Consequences
 
 Positive:
 
-* A draft is read in the context that decides whether it works, not in isolation.
-* The private and preview readings have the same shape, so what the private read
-  shows carries over to the preview one.
-* No structure is invented for this target; the context is the public site as it
-  actually is.
+* The private build stays cheap: three drafts render without rendering the whole
+  public site.
+* The output is obviously not a site, which is itself a safeguard against
+  mistaking it for one.
+* No structure is invented for this target, so nothing in it can drift from a
+  site that exists.
+* The collision rule moves a class of promotion failure to the point where the
+  draft is written instead of the point where it is published.
 
 Negative:
 
-* Every private render also renders the public site, which is most of the build
-  time for three drafts.
-* The output looks like a complete, deployable site while containing unpublished
-  content. That is the risk this record introduces, and it is the reason the
-  target keeps `noindex` on every page and is deployed by nothing.
-* A composition rule is now part of the build: two trees, one output, and a
-  defined winner. That is one more thing to understand when the target surprises
-  someone.
-
-=== Open Questions For Review
-
-. **Collision rule.** The decision above says the private tree wins. The
-  alternative — fail the build on a collision — would catch a draft that
-  accidentally shadows a published page. Which is wanted is not obvious, and the
-  answer belongs in this record before it is accepted.
-. **Whether the public articles appear in the private target's listings.** The
-  private status set includes `published`, so they would. That is probably right,
-  and it means the listings in the private target are longer than the ones in the
-  private repository's own content.
-. **What keeps the merged output from being deployed.** Today nothing deploys it
-  and `noindex` is on every page. Whether that is enough once the output looks
-  like a whole site is a question for this record rather than for the slice that
-  implements it.
+* Links out of a draft do not resolve, and the reader has to separate the
+  draft's defects from the target's.
+* The private reading and the later preview reading have different shapes, so
+  what the private read shows about page context carries over only partly.
+* The safeguard against publishing a non-public target now lives in CI, away
+  from the target it protects. A pipeline change is what would break it, and
+  that is the thing #95 has to make visible.
 
 === Implementation Status
 
-Not implemented. https://github.com/dieterbaier/profile/issues/86[#86] built the
-*private content only* option, which is the second column of the matrix above. If
-this record is accepted, that behaviour changes and the change belongs to its own
-slice rather than to #86, which is already complete against its own acceptance
-criteria.
+The decision holds; the rules it accepts are at different stages.
+
+[cols="2,1,2", options="header"]
+|===
+| Rule | State | Where
+| Private target rendered from private source alone | implemented | `buildSitePrivate` in `build.gradle`, https://github.com/dieterbaier/profile/issues/86[#86]
+| Theme, includes, and page chrome come from this repository | implemented | `--includes-dir` in `scripts/validate-profile-metamodel.rb` and the `includesdir` attribute, https://github.com/dieterbaier/profile/issues/86[#86]
+| Collision between private and public source is an error | decided, not implemented | https://github.com/dieterbaier/profile/issues/94[#94]
+| The pipeline keeps non-public targets out of the public deployment | decided, not implemented | https://github.com/dieterbaier/profile/issues/95[#95]
+|===
+
+Until https://github.com/dieterbaier/profile/issues/94[#94] closes, a private
+draft can carry an artifact `id` or an output path that a public artifact already
+uses, and nothing says so until the article is promoted. Until
+https://github.com/dieterbaier/profile/issues/95[#95] closes, no check stops a
+workflow edit from pointing the public deployment at a non-public target.

--- a/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
+++ b/src-content/docs/arc42/doc-08000-crosscutting-concepts.adoc
@@ -83,6 +83,42 @@ The observable behaviour is specified in
 `features/article-publication-status.feature` and bridged to
 `test/profile_publication_status_test.rb`.
 
+== Private Content Target
+
+A second target renders the private repository's content locally, so a draft can
+be read as a finished page before anything is decided about it. It carries
+`private`, `preview`, and `published`, which is a wider status set than the
+public target and safe only because it is a wider set for a target that is
+deployed nowhere.
+
+Both targets ask the same question of the same validator; only the answer
+differs, because the status set belongs to the target rather than to the
+mechanism. The private target renders to HTML alone: the markdown export exists
+so public articles can be published elsewhere, and a private draft is published
+nowhere.
+
+The private repository holds content only. Its build reaches this repository's
+tooling through a sibling checkout, resolved from `PROFILE_PRIVATE_DIR` or from
+the sibling path, and the build stops when that checkout carries a schema,
+validator, generator, or build of its own. The interface terms and theme come
+from this repository too, which is why the validator takes the includes tree as
+a parameter rather than assuming it sits inside the content root.
+
+Every page of the target carries a robots `noindex` tag and no canonical link.
+The two belong together: a page that says it must not be indexed while also
+claiming to be the canonical location of its content states two opposite things,
+and the build refuses to be asked for both. Neither is a confidentiality control.
+
+A checkout without the sibling is an ordinary state of this repository. Nothing
+about the private target may fail while the build configures itself, because that
+would break every Gradle invocation instead of the one task that needs the
+sibling.
+
+The observable behaviour is specified in
+`features/private-content-target.feature` and bridged to
+`test/profile_private_target_test.rb` and
+`test/private_checkout_contract_test.rb`.
+
 == Observability
 
 CI logs, Gradle task output, and validator reports are the operational feedback loop.

--- a/test/private_checkout_contract_test.rb
+++ b/test/private_checkout_contract_test.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for the sibling-checkout contract of the
+# private target.
+#
+# These scenarios are Gradle-level: the rules live in the build, so the only
+# honest verification runs the build. Each test invokes the real task with
+# PROFILE_PRIVATE_DIR pointed at a temporary tree, so the sibling arrangement is
+# exercised without the real private repository.
+#
+# This costs a Gradle start per test, which is why it is a separate file with its
+# own task rather than part of the fast metadata suite.
+#
+# Bridged from features/private-content-target.feature by the sanitized
+# scenario title.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'open3'
+
+class PrivateCheckoutContractTest < Minitest::Test
+  ROOT = File.expand_path('..', __dir__)
+
+  def gradle(task, private_dir:)
+    Open3.capture3(
+      { 'PROFILE_PRIVATE_DIR' => private_dir.to_s },
+      './gradlew', '--quiet', '--console=plain', task,
+      chdir: ROOT
+    )
+  end
+
+  def content_root(dir)
+    path = Pathname.new(dir) + 'src-content/profile/site/articles'
+    path.mkpath
+    path
+  end
+
+  def test_a_missing_sibling_checkout_names_the_path_it_expected
+    # Given: no checkout at the configured path
+    missing = File.join(Dir.tmpdir, 'profile-private-absent-on-purpose')
+    refute File.exist?(missing)
+
+    # When: the private target is asked for
+    _out, err, status = gradle('checkPrivateCheckout', private_dir: missing)
+
+    # Then: the build stops naming what it expected and where
+    refute_predicate status, :success?
+    assert_includes err, 'private content checkout was not found'
+    assert_includes err, missing
+  end
+
+  def test_a_checkout_without_a_content_root_names_the_directory_it_expected
+    # Given: a checkout that exists but carries no content root
+    Dir.mktmpdir('profile-private-empty') do |dir|
+      # When: the private target is asked for
+      _out, err, status = gradle('checkPrivateCheckout', private_dir: dir)
+
+      # Then: the build stops naming the content root it expected
+      refute_predicate status, :success?
+      assert_includes err, 'no content root'
+      assert_includes err, File.join(dir, 'src-content/profile/site')
+    end
+  end
+
+  def test_a_checkout_carrying_its_own_tooling_stops_the_build
+    # Given: a private checkout with a schema of its own
+    Dir.mktmpdir('profile-private-with-tooling') do |dir|
+      content_root(dir)
+      (Pathname.new(dir) + 'metamodel').mkpath
+      (Pathname.new(dir) + 'metamodel/profile-artifact.schema.yaml').write("type: object\n")
+
+      # When: the private target is asked for
+      _out, err, status = gradle('checkPrivateCheckout', private_dir: dir)
+
+      # Then: the build stops and names the copy it found
+      refute_predicate status, :success?
+      assert_includes err, 'carries its own tooling'
+      assert_includes err, 'metamodel'
+    end
+  end
+
+  def test_an_absent_sibling_leaves_the_rest_of_the_build_alone
+    # Given: no private checkout at the configured path
+    missing = File.join(Dir.tmpdir, 'profile-private-absent-on-purpose')
+    refute File.exist?(missing)
+
+    # When: a task that has nothing to do with the private target runs
+    _out, err, status = gradle('validateProfileMetamodel', private_dir: missing)
+
+    # Then: it succeeds, because a checkout without the sibling is an ordinary
+    # state of this repository rather than a broken one
+    assert_predicate status, :success?, err
+  end
+end

--- a/test/private_checkout_contract_test.rb
+++ b/test/private_checkout_contract_test.rb
@@ -80,6 +80,52 @@ class PrivateCheckoutContractTest < Minitest::Test
     end
   end
 
+  # A checkout that exists but whose content cannot be resolved. The sidecar
+  # names an article file that is not there, which is what the publication
+  # selection refuses to guess at.
+  def unresolvable_content(dir)
+    articles = content_root(dir)
+    (articles + 'ghost.profile.yaml').write(<<~YAML)
+      id: ART-999-ghost
+      type: Article
+      title: "Ghost"
+      status: draft
+      owner: "Test Owner"
+      created: '2026-01-01'
+      source: src-content/profile/site/articles/ghost.adoc
+      metadata_version: '1.0'
+    YAML
+  end
+
+  def test_an_unreadable_sibling_leaves_the_rest_of_the_build_alone
+    # Given: a private checkout whose content cannot be resolved
+    Dir.mktmpdir('profile-private-unreadable') do |dir|
+      unresolvable_content(dir)
+
+      # When: a task that has nothing to do with the private target runs
+      _out, err, status = gradle('validateArchitectureMetamodel', private_dir: dir)
+
+      # Then: it succeeds. The private selection runs while the build configures
+      # itself, so a failure there would break every invocation rather than the
+      # one task that needs the private tree.
+      assert_predicate status, :success?, err
+    end
+  end
+
+  def test_an_unreadable_sibling_stops_the_private_target
+    # Given: a private checkout whose content cannot be resolved
+    Dir.mktmpdir('profile-private-unreadable') do |dir|
+      unresolvable_content(dir)
+
+      # When: the private target is built
+      out, err, status = gradle('buildSitePrivate', private_dir: dir)
+
+      # Then: the build stops naming the content it could not resolve
+      refute_predicate status, :success?
+      assert_includes(out + err, 'ghost.adoc')
+    end
+  end
+
   def test_an_absent_sibling_leaves_the_rest_of_the_build_alone
     # Given: no private checkout at the configured path
     missing = File.join(Dir.tmpdir, 'profile-private-absent-on-purpose')

--- a/test/profile_private_target_test.rb
+++ b/test/profile_private_target_test.rb
@@ -1,0 +1,252 @@
+# frozen_string_literal: true
+
+# Behaviour specification bridge for the private content target.
+#
+# Minitest is a classic (non-BDD) runner, so each test method name is a
+# sanitized translation of a scenario title in
+# features/private-content-target.feature, with Given/When/Then comment anchors
+# separating Arrange, Act, and Assert.
+#
+# Every test builds temporary trees for the sibling arrangement: a content root
+# that owns no includes, an includes tree that does, and an output root that is
+# neither. The real private repository is never touched.
+
+require 'minitest/autorun'
+require 'tmpdir'
+require 'pathname'
+require 'yaml'
+require 'open3'
+
+require_relative '../scripts/validate-profile-metamodel'
+require_relative '../scripts/inject-site-metadata'
+
+class ProfilePrivateTargetTest < Minitest::Test
+  UI_TERMS = ":ui_article_list_all: Alle Artikel\n" \
+             ":ui_article_list_tag_prefix: Artikel mit dem Tag:\n" \
+             ":ui_article_list_skill_prefix: Artikel zum Thema:\n"
+
+  INJECTOR = File.expand_path('../scripts/inject-site-metadata.rb', __dir__)
+
+  # A content root shaped like the private repository: articles and their
+  # sidecars, and deliberately no includes of its own.
+  def with_private_content(specs)
+    Dir.mktmpdir('profile-private-content') do |content|
+      Dir.mktmpdir('profile-private-includes') do |includes|
+        root = Pathname.new(content)
+        includes_root = Pathname.new(includes)
+        (includes_root + 'i18n').mkpath
+        (includes_root + 'i18n/ui-de.adoc').write(UI_TERMS)
+
+        (root + 'src-content/profile/site/articles').mkpath
+        specs.each do |spec|
+          slug = spec.fetch(:slug)
+          source_rel = "src-content/profile/site/articles/#{slug}.adoc"
+          (root + source_rel).write("= #{slug}\n")
+          (root + "src-content/profile/site/articles/#{slug}.profile.yaml").write(metadata_yaml(spec, source_rel))
+        end
+
+        validator = ProfileArtifactValidator.new(
+          root: root,
+          profile_dir: root + 'src-content/profile',
+          includes_dir: includes_root
+        )
+        yield(validator, validator.scan_artifacts, root)
+      end
+    end
+  end
+
+  def metadata_yaml(spec, source_rel)
+    {
+      'id' => spec.fetch(:id),
+      'type' => 'Article',
+      'title' => spec.fetch(:slug),
+      'status' => spec.fetch(:status),
+      'owner' => 'Test Owner',
+      'created' => '2026-01-01',
+      'source' => source_rel,
+      'metadata_version' => ProfileArtifactValidator.supported_metadata_versions.first
+    }.to_yaml
+  end
+
+  def page(body)
+    "<html><head><title>t</title>#{body}</head><body>p</body></html>"
+  end
+
+  def write_page(dir, relative, body)
+    path = Pathname.new(dir) + relative
+    path.dirname.mkpath
+    path.write(page(body), encoding: 'UTF-8')
+    path
+  end
+
+  def test_the_private_target_renders_drafts_alongside_published_articles
+    # Given: private, preview, and published articles in the private content root
+    specs = ProfileArtifactValidator::TARGET_STATUSES.fetch('private').each_with_index.map do |status, index|
+      { id: format('ART-7%02d-%s', index, status), slug: status, status: status }
+    end
+
+    with_private_content(specs) do |validator, artifacts, _root|
+      # When: the private article selection is computed
+      excluded = validator.excluded_article_sources(artifacts, target: 'private')
+
+      # Then: none of their sources is excluded from the private target
+      assert_empty excluded
+    end
+  end
+
+  def test_a_status_that_belongs_to_no_target_is_kept_out_of_the_private_one
+    # Given: articles with every status neither target renders
+    statuses = ProfileArtifactValidator::STATUSES - ProfileArtifactValidator::TARGET_STATUSES.fetch('private')
+    specs = statuses.each_with_index.map do |status, index|
+      { id: format('ART-8%02d-%s', index, status), slug: status, status: status }
+    end
+
+    with_private_content(specs) do |validator, artifacts, _root|
+      # When: the private article selection is computed
+      excluded = validator.excluded_article_sources(artifacts, target: 'private')
+
+      # Then: every one of their sources is excluded from the private target
+      expected = statuses.map { |status| "src-content/profile/site/articles/#{status}.adoc" }.sort
+      assert_equal expected, excluded
+    end
+  end
+
+  def test_an_article_the_private_target_renders_is_still_absent_from_the_public_one
+    # Given: a private article and a preview article
+    specs = [
+      { id: 'ART-901-private', slug: 'private', status: 'private' },
+      { id: 'ART-902-preview', slug: 'preview', status: 'preview' }
+    ]
+
+    with_private_content(specs) do |validator, artifacts, _root|
+      # When: the public article selection is computed
+      excluded = validator.excluded_article_sources(artifacts, target: 'public')
+
+      # Then: both of their sources are excluded from the public target
+      assert_equal(
+        ['src-content/profile/site/articles/preview.adoc', 'src-content/profile/site/articles/private.adoc'],
+        excluded
+      )
+    end
+  end
+
+  def test_interface_terms_come_from_the_tree_that_owns_them
+    # Given: a content root without interface terms and a separate tree that has them
+    with_private_content([{ id: 'ART-903-draft', slug: 'draft', status: 'private' }]) do |validator, _artifacts, root|
+      refute (root + 'src-content/profile/includes').exist?, 'the content root must own no includes'
+
+      # When: the profile metadata is validated against that includes tree
+      validator.validate
+
+      # Then: validation passes without the content root holding a copy
+      assert_empty validator.errors
+    end
+  end
+
+  def test_a_content_root_with_no_interface_terms_anywhere_stops_the_build
+    # Given: a content root and an includes tree that both lack interface terms
+    Dir.mktmpdir('profile-private-content') do |content|
+      Dir.mktmpdir('profile-private-includes') do |includes|
+        root = Pathname.new(content)
+        (root + 'src-content/profile/site/articles').mkpath
+        (root + 'src-content/profile/site/articles/draft.adoc').write("= draft\n")
+        (root + 'src-content/profile/site/articles/draft.profile.yaml').write(
+          metadata_yaml({ id: 'ART-904-draft', slug: 'draft', status: 'private' },
+                        'src-content/profile/site/articles/draft.adoc')
+        )
+
+        validator = ProfileArtifactValidator.new(
+          root: root, profile_dir: root + 'src-content/profile', includes_dir: includes
+        )
+
+        # When: the profile metadata is validated
+        validator.validate
+
+        # Then: validation fails naming the interface terms it expected
+        assert(validator.errors.any? { |error| error.include?('missing interface terms') && error.include?('ui-de.adoc') })
+      end
+    end
+  end
+
+  def test_every_page_of_the_private_target_is_marked_as_not_to_be_indexed
+    # Given: a rendered target whose pages carry a canonical link
+    Dir.mktmpdir('site-private') do |dir|
+      write_page(dir, 'index.html', '<link rel="canonical" href="https://example.org/">')
+      write_page(dir, 'articles/ai/draft.html', '<link rel="canonical" href="https://example.org/a">')
+
+      # When: the target is marked as not indexed
+      marked = RobotsNoindexInjector.new(site_dir: dir).inject
+
+      # Then: every page carries a robots noindex tag and no canonical link
+      assert_equal 2, marked.length
+      Pathname.glob(File.join(dir, '**/*.html')).each do |path|
+        content = path.read
+        assert_includes content, '<meta name="robots" content="noindex, nofollow">'
+        refute_includes content, 'canonical'
+      end
+    end
+  end
+
+  def test_marking_a_target_twice_leaves_one_robots_tag
+    # Given: a rendered target that was already marked as not indexed
+    Dir.mktmpdir('site-private') do |dir|
+      path = write_page(dir, 'index.html', '')
+      RobotsNoindexInjector.new(site_dir: dir).inject
+
+      # When: the target is marked as not indexed again
+      RobotsNoindexInjector.new(site_dir: dir).inject
+
+      # Then: each page carries exactly one robots tag
+      assert_equal 1, path.read.scan('name="robots"').length
+    end
+  end
+
+  def test_a_target_cannot_be_both_unindexed_and_canonical
+    # Given: a request to mark a target as not indexed
+    Dir.mktmpdir('site-private') do |dir|
+      write_page(dir, 'index.html', '')
+
+      # When: a base URL is supplied with it
+      _out, err, status = Open3.capture3(
+        'ruby', INJECTOR, '--site-dir', dir, '--noindex', '--base-url', 'https://example.org'
+      )
+
+      # Then: the request is refused rather than resolved in favour of one of them
+      refute_predicate status, :success?
+      assert_includes err, 'mutually exclusive'
+    end
+  end
+
+  def test_output_of_an_article_the_private_target_must_not_contain_is_reported
+    # Given: a rendered private target holding the page of a draft article
+    with_private_content([{ id: 'ART-905-draft', slug: 'draft', status: 'draft' }]) do |validator, artifacts, root|
+      output = root + 'build/site-private/articles/draft.html'
+      output.dirname.mkpath
+      output.write("rendered\n")
+
+      # When: the rendered target is checked against the private status set
+      reported = validator.unexpected_target_outputs(artifacts, target: 'private')
+
+      # Then: that page is reported
+      assert_equal ['build/site-private/articles/draft.html'], reported
+    end
+  end
+
+  def test_the_private_target_is_checked_where_it_is_rendered_not_where_its_content_lives
+    # Given: private content in one tree and its rendered target in another
+    with_private_content([{ id: 'ART-906-draft', slug: 'draft', status: 'draft' }]) do |validator, artifacts, root|
+      Dir.mktmpdir('public-checkout') do |output_root|
+        output = Pathname.new(output_root) + 'build/site-private/articles/draft.html'
+        output.dirname.mkpath
+        output.write("rendered\n")
+        refute (root + 'build').exist?, 'the content root holds no rendered target'
+
+        # When: the rendered target is checked
+        reported = validator.unexpected_target_outputs(artifacts, target: 'private', output_root: output_root)
+
+        # Then: the reported path is relative to the tree holding the target
+        assert_equal ['build/site-private/articles/draft.html'], reported
+      end
+    end
+  end
+end


### PR DESCRIPTION
Closes https://github.com/dieterbaier/profile/issues/86

`buildSitePrivate` renders the private repository's content with this repository's tooling, into `build/site-private`. It is the first slice that reads private source, and it was gated behind #83 until this morning.

## What the sibling arrangement cost

Three things had to give, and none of them was wiring:

**The validator assumed the content root owns its includes.** It does not — a private repository holding a copy of the interface terms and theme is exactly what ADR-009 forbids, because a copy keeps looking like the original after it has stopped being one. The includes tree is now a parameter, defaulting to the content root's own `includes`, so the public tree is unchanged.

**The result check had to follow the target to where it is rendered.** Private content lives in one checkout and its output in another, so the output root is separate from the content root and paths are reported relative to the tree they belong to.

**Nothing may fail while the build configures itself.** A checkout without the sibling is an ordinary state of this repository, not a broken one. The exclusion list is only computed when there is a tree to ask about, and `checkPrivateCheckout` fails at execution with a message naming the path it expected. There is a scenario for exactly this, because the failure it guards against is invisible in the warm state — the same shape as the publication selection that once read a file written mid-build.

## Target rules

`TARGET_STATUSES` gains `private` (`private`, `preview`, `published`). Same mechanism, different set: a wider set is safe for a target that is read locally and deployed nowhere, and would not be for the public one. The target renders HTML only, since the markdown export exists so public articles can be published elsewhere and a private draft is published nowhere.

Every page carries `noindex` and no canonical link. `--noindex` is a separate injector rather than an option on the canonical one, and `--noindex --base-url` together is refused: a target that must not be indexed claims no canonical URL, and resolving that silently would pick one of two opposite statements about the same page.

`checkPrivateCheckout` also stops the build when the private checkout carries a schema, validator, generator, or build of its own — ADR-009's no-second-implementation rule, read as a question about files.

## Found by running the documented path

`./build.sh buildSitePrivate` reported a missing sibling that was present on the host: the container mounts `$PWD`, and the sibling sits next to it. Only `./gradlew` had been exercised. Fixed, and both entry points now agree.

## Architecture impact

ADR-009's implementation status moves two rules to implemented and names the task enforcing each. It also records what is **not** built: the private target runs no generators, so a private page has no tags, no navigation, and no series links. The reason is a real coupling rather than unfinished wiring — the generators write link registries into the includes tree, which for this target is the public one, so a generator run would write into the public checkout while rendering private content. That is left to its own slice.

ADR-012 is new and accepted: the private target renders private source alone, with links out of it that do not resolve. The Pugh matrix scores the composing option one point higher; the owner weighed reading context against cost and predictability and chose otherwise, and the matrix is left as it was scored rather than re-weighted to agree with the outcome. Its two rules are #94 (collisions are an error, early) and #95 (the pipeline keeps non-public targets out of the public deployment), both decided and unbuilt.

The README gains the lifecycle and links the private repository, which is not publicly reachable but makes the public half easier to read.

## Verification

```
./gradlew buildSitePrivate          # 3 pages, verifyPrivateTargetHasOnlyAllowedArticles passes
./build.sh buildSitePrivate         # same, through the container
./gradlew buildSite                 # public target unchanged, no ai-* output in build/site
./gradlew validateProfileMetamodel validateArchitectureMetamodel
```

- 12 test files, 135 runs, 461+ assertions, 0 failures.
- 14 scenarios in `features/private-content-target.feature`, bridged to two files: metadata behaviour runs in milliseconds, and the sibling-checkout contract invokes real Gradle tasks against temporary trees (~5s, own task).
- Failure paths exercised by hand as well as by test: missing sibling, missing content root, sibling carrying `metamodel/`.
- The public build was checked for absence, not only for success: no `ai-*` output anywhere in `build/site`.

## Also in this branch

CI gained `testProfileMetadataVersion`, which had a test file and no task since #83 — a test nothing runs is not a check. Four further test tasks (`testProfileLanguage`, `testProfileCvLanguage`, `testProfileLanguageAlternates`, `testProfileTranslation`) are registered and still absent from CI, and `test/profile_publication_status_test.rb` has no task at all. That predates this branch and is left for its own issue rather than folded in here.